### PR TITLE
Python 2.4 compatibility

### DIFF
--- a/python/benchmark.py
+++ b/python/benchmark.py
@@ -1,7 +1,11 @@
 ﻿# coding=UTF-8
 import simplejson
 import ujson
-import json
+import sys
+try:
+    import json
+except ImportError:
+    json = simplejson
 import cjson
 from time import time as gettime
 import time
@@ -51,9 +55,28 @@ def cjsonDec():
 
 """=========================================================================="""
 
+def timeit_compat_fix(timeit):
+    if sys.version_info[:2] >=  (2,6):
+        return
+    default_number = 1000000
+    default_repeat = 3
+    if sys.platform == "win32":
+        # On Windows, the best timer is time.clock()
+        default_timer = time.clock
+    else:
+        # On most other platforms the best timer is time.time()
+        default_timer = time.time
+    def repeat(stmt="pass", setup="pass", timer=default_timer,
+       repeat=default_repeat, number=default_number):
+        """Convenience function to create Timer object and call repeat method."""
+        return timeit.Timer(stmt, setup, timer).repeat(repeat, number)
+    timeit.repeat = repeat
+
 
 if __name__ == "__main__":
     import timeit
+    timeit_compat_fix(timeit)
+
 
 print "Ready? Configure affinity and priority, starting in 20..."
 time.sleep(20)

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -8,6 +8,12 @@ static PyObject* mod_calendar;
 
 typedef void *(*PFN_PyTypeToJSON)(JSOBJ obj, JSONTypeContext *ti, void *outValue, size_t *_outLen);
 
+
+#if (PY_VERSION_HEX < 0x02050000)
+typedef ssize_t Py_ssize_t;
+#endif
+
+
 typedef struct __TypeContext
 {
 	JSPFN_ITERBEGIN iterBegin;

--- a/python/tests.py
+++ b/python/tests.py
@@ -3,7 +3,10 @@ import unittest
 from unittest import TestCase
 
 import ujson
-import json
+try:
+    import json
+except ImportError:
+    import simplejson as json
 import math
 import time
 import datetime


### PR DESCRIPTION
Hi Jonas,

This is a Python 2.4 compatibility update for ultrajson. 

Unfortunately many RHEL/CentOS (5.X) servers out there are still stuck with Python 2.4. It looks like only a single #ifdef took care of compatibility. Then I also updated benchmark.py and test.py to account for the missing built-in json and a missing method from the timeit module.

Here is the benchmark run  from a 32bit CentOS 5.6 (Python 2.4) machine:

Array with 256 utf-8 strings:
ujson encode      : 1453.30891 calls/sec
simplejson encode : 658.31181 calls/sec
cjson encode      : 62.18416 calls/sec
ujson decode      : 1016.58767 calls/sec
cjson decode      : 455.28550 calls/sec
simplejson decode : 124.20439 calls/sec
Medium complex object:
ujson encode      : 6010.21634 calls/sec
simplejson encode : 1418.77823 calls/sec
cjson encode      : 1252.92530 calls/sec
ujson decode      : 4637.52630 calls/sec
cjson decode      : 3444.13604 calls/sec
simplejson decode : 2166.18641 calls/sec
Array with 256 strings:
ujson encode      : 12252.28889 calls/sec
simplejson encode : 9351.67532 calls/sec
cjson encode      : 7786.13697 calls/sec
ujson decode      : 10951.17394 calls/sec
cjson decode      : 15971.02425 calls/sec
simplejson decode : 6796.77480 calls/sec
Array with 256 doubles:
ujson encode      : 16300.61218 calls/sec
simplejson encode : 1613.39428 calls/sec
cjson encode      : 2035.58937 calls/sec
ujson decode      : 17301.00746 calls/sec
cjson decode      : 5785.33627 calls/sec
simplejson decode : 6199.49364 calls/sec
Array with 256 True values:
ujson encode      : 72618.15350 calls/sec
simplejson encode : 18707.57593 calls/sec
cjson encode      : 24150.26201 calls/sec
ujson decode      : 53650.94162 calls/sec
cjson decode      : 48069.53050 calls/sec
simplejson decode : 47098.40293 calls/sec
Array with 256 dict{string, int} pairs:
ujson encode      : 8811.85922 calls/sec
simplejson encode : 2756.91262 calls/sec
cjson encode      : 1758.26962 calls/sec
ujson decode      : 6490.36358 calls/sec
cjson decode      : 6330.77263 calls/sec
simplejson decode : 4161.97048 calls/sec
Dict with 256 arrays with 256 dict{string, int} pairs:
ujson encode      : 31.08834 calls/sec
simplejson encode : 10.41434 calls/sec
cjson encode      : 6.93790 calls/sec
ujson decode      : 19.81373 calls/sec
cjson decode      : 20.31727 calls/sec
simplejson decode : 15.05690 calls/sec

Thank you,
- Nick
