### PR TITLE
Added dump/load functions that take a file object

### DIFF
--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -142,21 +142,21 @@ PyObject* JSONFileToObj(PyObject* self, PyObject *file)
 		return NULL;
 	}
 
-    string = PyObject_CallObject (read, NULL);
-    Py_XDECREF(read);
+	string = PyObject_CallObject (read, NULL);
+	Py_XDECREF(read);
 
 	if (string == NULL)
 	{
 		return NULL;
 	}
 
-    result = JSONToObj (self, string);
-    Py_XDECREF(string);
+	result = JSONToObj (self, string);
+	Py_XDECREF(string);
 
-    if (result == NULL) {
-        return NULL;
-    }
+	if (result == NULL) {
+		return NULL;
+	}
 
-    return result;
+	return result;
 }
 

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -121,3 +121,42 @@ PyObject* JSONToObj(PyObject* self, PyObject *arg)
 	
 	return ret;
 }
+
+PyObject* JSONFileToObj(PyObject* self, PyObject *file)
+{
+	PyObject *read;
+	PyObject *string;
+	PyObject *result;
+
+	if (!PyObject_HasAttrString (file, "read"))
+	{
+		PyErr_Format (PyExc_TypeError, "expected file");
+		return NULL;
+	}
+
+	read = PyObject_GetAttrString (file, "read");
+
+	if (!PyCallable_Check (read)) {
+		Py_XDECREF(read);
+		PyErr_Format (PyExc_TypeError, "expected file");
+		return NULL;
+	}
+
+    string = PyObject_CallObject (read, NULL);
+    Py_XDECREF(read);
+
+	if (string == NULL)
+	{
+		return NULL;
+	}
+
+    result = JSONToObj (self, string);
+    Py_XDECREF(string);
+
+    if (result == NULL) {
+        return NULL;
+    }
+
+    return result;
+}
+

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -715,15 +715,15 @@ PyObject* objToJSON(PyObject* self, PyObject *arg)
 
 PyObject* objToJSONFile(PyObject* self, PyObject *args)
 {
-    PyObject *data;
-    PyObject *file;
+	PyObject *data;
+	PyObject *file;
 	PyObject *string;
 	PyObject *write;
 	PyObject *argtuple;
 
-    if (!PyArg_ParseTuple (args, "OO", &data, &file)) {
-        return NULL;
-    }
+	if (!PyArg_ParseTuple (args, "OO", &data, &file)) {
+		return NULL;
+	}
 
 	if (!PyObject_HasAttrString (file, "write"))
 	{

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include <stdio.h>
 #include <datetime.h>
 #include <ultrajson.h>
 
@@ -711,3 +712,57 @@ PyObject* objToJSON(PyObject* self, PyObject *arg)
 
 	return newobj;
 }
+
+PyObject* objToJSONFile(PyObject* self, PyObject *args)
+{
+    PyObject *data;
+    PyObject *file;
+	PyObject *string;
+	PyObject *write;
+	PyObject *argtuple;
+
+    if (!PyArg_ParseTuple (args, "OO", &data, &file)) {
+        return NULL;
+    }
+
+	if (!PyObject_HasAttrString (file, "write"))
+	{
+		PyErr_Format (PyExc_TypeError, "expected file");
+		return NULL;
+	}
+
+	write = PyObject_GetAttrString (file, "write");
+
+	if (!PyCallable_Check (write)) {
+		Py_XDECREF(write);
+		PyErr_Format (PyExc_TypeError, "expected file");
+		return NULL;
+	}
+
+	string = objToJSON (self, data);
+
+	if (string == NULL)
+	{
+		Py_XDECREF(write);
+		return NULL;
+	}
+
+	argtuple = PyTuple_Pack (1, string);
+	if (argtuple == NULL)
+	{
+		Py_XDECREF(write);
+		return NULL;
+	}
+	if (PyObject_CallObject (write, argtuple) == NULL)
+	{
+		Py_XDECREF(write);
+		Py_XDECREF(argtuple);
+		return NULL;
+	}
+
+	Py_XDECREF(write);
+	Py_XDECREF(argtuple);
+	Py_XDECREF(string);
+	Py_RETURN_NONE;
+}
+

--- a/python/tests.py
+++ b/python/tests.py
@@ -11,6 +11,7 @@ import math
 import time
 import datetime
 import calendar
+import StringIO
 
 class UltraJSONTests(TestCase):
 
@@ -505,6 +506,52 @@ class UltraJSONTests(TestCase):
         for x in xrange(10):
             input = "\"" + ("\xc3\xa5" * 1024 * 1024 * 10) + "\""
             output = ujson.decode(input)
+
+    def test_dumpToFile(self):
+        f = StringIO.StringIO()
+        ujson.dump([1, 2, 3], f)
+        self.assertEquals("[1,2,3]", f.getvalue())
+
+    def test_dumpToFileLikeObject(self):
+        class filelike:
+            def __init__(self):
+                self.bytes = ''
+            def write(self, bytes):
+                self.bytes += bytes
+        f = filelike()
+        ujson.dump([1, 2, 3], f)
+        self.assertEquals("[1,2,3]", f.bytes)
+
+    def test_dumpFileArgsError(self):
+        try:
+            ujson.dump([], '')
+        except TypeError:
+            pass
+        else:
+            assert False, 'expected TypeError'
+
+    def test_loadFile(self):
+        f = StringIO.StringIO("[1,2,3,4]")
+        self.assertEquals([1, 2, 3, 4], ujson.load(f))
+
+    def test_loadFileLikeObject(self):
+        class filelike:
+            def read(self):
+                try:
+                    self.end
+                except AttributeError:
+                    self.end = True
+                    return "[1,2,3,4]"
+        f = filelike()
+        self.assertEquals([1, 2, 3, 4], ujson.load(f))
+
+    def test_loadFileArgsError(self):
+        try:
+            ujson.load("[]")
+        except TypeError:
+            pass
+        else:
+            assert False, "expected TypeError"
     
 """
 def test_decodeNumericIntFrcOverflow(self):

--- a/python/ujson.c
+++ b/python/ujson.c
@@ -21,7 +21,7 @@ static PyMethodDef ujsonMethods[] = {
 	{"loads", JSONToObj, METH_O,  "Converts JSON as string to dict object structure"},
 	{"dump", objToJSONFile, METH_VARARGS, "Converts arbitrary object recursively into JSON file"},
 	{"load", JSONFileToObj, METH_O, "Converts JSON as file to dict object structure"},
-    {NULL, NULL, 0, NULL}        /* Sentinel */
+	{NULL, NULL, 0, NULL}		/* Sentinel */
 };
 
 
@@ -30,6 +30,6 @@ PyMODINIT_FUNC
 initujson(void)
 {
 	initObjToJSON();
-    Py_InitModule("ujson", ujsonMethods);
+	Py_InitModule("ujson", ujsonMethods);
 
 }

--- a/python/ujson.c
+++ b/python/ujson.c
@@ -7,12 +7,20 @@ void initObjToJSON();
 /* JSONToObj */
 PyObject* JSONToObj(PyObject* self, PyObject *arg);
 
+/* objToJSONFile */
+PyObject* objToJSONFile(PyObject* self, PyObject *args);
+
+/* JSONFileToObj */
+PyObject* JSONFileToObj(PyObject* self, PyObject *file);
+
 
 static PyMethodDef ujsonMethods[] = {
 	{"encode", objToJSON, METH_O, "Converts arbitrary object recursivly into JSON"},
 	{"decode", JSONToObj, METH_O, "Converts JSON as string to dict object structure"},
 	{"dumps", objToJSON, METH_O,  "Converts arbitrary object recursivly into JSON"},
 	{"loads", JSONToObj, METH_O,  "Converts JSON as string to dict object structure"},
+	{"dump", objToJSONFile, METH_VARARGS, "Converts arbitrary object recursively into JSON file"},
+	{"load", JSONFileToObj, METH_O, "Converts JSON as file to dict object structure"},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 


### PR DESCRIPTION
As I mentioned from the issue #18, I added `dump` and `load` functions that take a file object to satisfy de facto standard interface for Python serialization modules. Now it can be a drop-in replacement for standard `json` or `simplejson`. That is, many softwares that use `json`/`simplejson` now can easily migrate from these modules to `ujson`. For example:

```
import ujson as json
```
