### PR TITLE
Small bug fix for ujson.__version__

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,6 +11,7 @@ except(OSError):
 
 module1 = Extension('ujson',
                     sources = ['ujson.c', 'objToJSON.c', 'JSONtoObj.c', '../ultrajsonenc.c', '../ultrajsondec.c'],
+                    headers = ['version.h'],
                     include_dirs = ['../'])
 
 def get_version():


### PR DESCRIPTION
`setup.py` seemed broken because it missed `version.h` file, but now resolved.

```
Traceback (most recent call last):
  File "<string>", line 14, in <module>
  File "/Users/dahlia/Projects/ujson-env/build/ujson/setup.py", line 30, in <module>
    version = get_version(),
  File "/Users/dahlia/Projects/ujson-env/build/ujson/setup.py", line 20, in get_version
    file = open(filename)
IOError: [Errno 2] No such file or directory: '/Users/dahlia/Projects/ujson-env/build/ujson/version.h'
```
