### PR TITLE
this fixes a decoding error with ints between 2**31 & 2**32

### DIFF
--- a/python/tests.py
+++ b/python/tests.py
@@ -590,10 +590,19 @@ class UltraJSONTests(TestCase):
 
     def test_decodeNumberWith32bitSignBit(self):
         """Test that numbers that fit within 32 bits but would have the
-        sign bit set (2**31 < x < 2**32) are decoded properly."""
-        doc = '{"id": 3590016419}'
-        self.assertEqual(ujson.decode(doc)['id'], 3590016419)
-               
+        sign bit set (2**31 <= x < 2**32) are decoded properly."""
+        boundary1 = 2**31
+        boundary2 = 2**32
+        docs = (
+            '{"id": 3590016419}',
+            '{"id": %s}' % 2**31,
+            '{"id": %s}' % 2**32,
+            '{"id": %s}' % ((2**32)-1),
+        )
+        results = (3590016419, 2**31, 2**32, 2**32-1)
+        for doc,result in zip(docs, results):
+            self.assertEqual(ujson.decode(doc)['id'], result)
+
 """
 def test_decodeNumericIntFrcOverflow(self):
 input = "X.Y"

--- a/python/tests.py
+++ b/python/tests.py
@@ -587,6 +587,12 @@ class UltraJSONTests(TestCase):
                 pass
             else:
                 assert False, "expected OverflowError"
+
+    def test_decodeNumberWith32bitSignBit(self):
+        """Test that numbers that fit within 32 bits but would have the
+        sign bit set (2**31 < x < 2**32) are decoded properly."""
+        doc = '{"id": 3590016419}'
+        self.assertEqual(ujson.decode(doc)['id'], 3590016419)
                
 """
 def test_decodeNumericIntFrcOverflow(self):

--- a/ultrajsondec.c
+++ b/ultrajsondec.c
@@ -159,7 +159,7 @@ BREAK_INT_LOOP:
 #ifdef JSON_DECODE_NUMERIC_AS_DOUBLE
 	if (intValue > (double) INT_MAX || intValue < (double) INT_MIN)
 #else
-	if ( (intValue >> 32))
+	if ( (intValue >> 31))
 #endif
 	{	
 		RETURN_JSOBJ_NULLCHECK(ds->dec->newLong( (JSINT64) (intValue * (JSINT64) intNeg)));


### PR DESCRIPTION
...ve signed values rather than the right value (for instance, try ujson.loads('{"id":3590016419}') and you will get {u'id': -704950877})
