### PR TITLE
Allow for a double_precision kwarg that specifies decimal places

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -681,13 +681,21 @@ char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 
 PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 {
-	static char *kwlist[] = { "obj", "ensure_ascii", NULL};
+	static char *kwlist[] = { "obj", "ensure_ascii", "double_precision", NULL};
 
 	char buffer[65536];
 	char *ret;
 	PyObject *newobj;
 	PyObject *oinput = NULL;
 	PyObject *oensureAscii = NULL;
+	int idoublePrecision = 5; // default double precision setting
+
+	PRINTMARK();
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Oi", kwlist, &oinput, &oensureAscii, &idoublePrecision))
+	{
+		return NULL;
+	}
 
 	JSONObjectEncoder encoder = 
 	{
@@ -707,17 +715,10 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 		PyObject_Realloc, //JSPFN_REALLOC realloc;
 		PyObject_Free, //JSPFN_FREE free;
 		-1, //recursionMax
-		5, //default decimal precision
+		idoublePrecision,
 		1, //forceAscii
 	};
 	
-	PRINTMARK();
-
-	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O", kwlist, &oinput, &oensureAscii))
-	{
-		return NULL;
-	}
-
 	if (oensureAscii != NULL && !PyObject_IsTrue(oensureAscii))
 	{
 		encoder.forceASCII = 0;

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,9 +10,9 @@ except(OSError):
 	pass
 
 module1 = Extension('ujson',
-                    sources = ['ujson.c', 'objToJSON.c', 'JSONtoObj.c', 'ultrajsonenc.c', 'ultrajsondec.c'],
+                    sources = ['ujson.c', 'objToJSON.c', 'JSONtoObj.c', '../ultrajsonenc.c', '../ultrajsondec.c'],
                     headers = ['version.h'],
-                    include_dirs = ['./'])
+                    include_dirs = ['./', '..'])
 
 def get_version():
 	filename = os.path.join(os.path.dirname(__file__), 'version.h')

--- a/python/tests.py
+++ b/python/tests.py
@@ -29,7 +29,6 @@ class UltraJSONTests(TestCase):
         output = ujson.encode(input)
         self.assertEquals(round(input, 5), round(json.loads(output), 5))
         self.assertEquals(round(input, 5), round(ujson.decode(output), 5))
-        pass
         
     def test_encodeWithDecimal(self):
         input = 1.0
@@ -41,7 +40,6 @@ class UltraJSONTests(TestCase):
         output = ujson.encode(input)
         self.assertEquals(round(input, 5), round(json.loads(output), 5))
         self.assertEquals(round(input, 5), round(ujson.decode(output), 5))
-        pass
 
     def test_encodeArrayOfNestedArrays(self):
         input = [[[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]], [[[]]] ]
@@ -56,6 +54,38 @@ class UltraJSONTests(TestCase):
         self.assertEquals(input, json.loads(output))
         #self.assertEquals(output, json.dumps(input))
         self.assertEquals(input, ujson.decode(output))
+
+    def test_doublePrecisionTest(self):
+        input = 30.012345678
+        output = ujson.encode(input, double_precision = 9)
+        self.assertEquals(input, json.loads(output))
+        self.assertEquals(input, ujson.decode(output))
+
+        output = ujson.encode(input, double_precision = 3)
+        self.assertEquals(round(input, 3), json.loads(output))
+        self.assertEquals(round(input, 3), ujson.decode(output))
+
+        output = ujson.encode(input)
+        self.assertEquals(round(input, 5), json.loads(output))
+        self.assertEquals(round(input, 5), ujson.decode(output))
+
+    def test_invalidDoublePrecision(self):
+        input = 30.12345678901234567890
+        output = ujson.encode(input, double_precision = 20)
+        # should snap to the max, which is 9
+        self.assertEquals(round(input, 9), json.loads(output))
+        self.assertEquals(round(input, 9), ujson.decode(output))
+
+        output = ujson.encode(input, double_precision = -1)
+        # also should snap to the max, which is 9
+        self.assertEquals(round(input, 9), json.loads(output))
+        self.assertEquals(round(input, 9), ujson.decode(output))
+
+        # will throw typeError
+        self.assertRaises(TypeError, ujson.encode, input, double_precision = '9')
+        # will throw typeError
+        self.assertRaises(TypeError, ujson.encode, input, double_precision = None)
+
 
     def test_encodeStringConversion(self):
         input = "A string \\ / \b \f \n \r \t"
@@ -676,4 +706,3 @@ if __name__ == '__main__':
         unittest.main()
         heap = hp.heapu()
         print heap    
-    

--- a/python/ujson.c
+++ b/python/ujson.c
@@ -16,7 +16,7 @@ PyObject* JSONFileToObj(PyObject* self, PyObject *file);
 
 
 static PyMethodDef ujsonMethods[] = {
-	{"encode", objToJSON, METH_VARARGS | METH_KEYWORDS, "Converts arbitrary object recursivly into JSON. Use ensure_ascii=false to output UTF-8"},
+	{"encode", objToJSON, METH_VARARGS | METH_KEYWORDS, "Converts arbitrary object recursivly into JSON. Use ensure_ascii=false to output UTF-8. Pass in double_precision to alter the maximum digit precision with doubles"},
 	{"decode", JSONToObj, METH_O, "Converts JSON as string to dict object structure"},
 	{"dumps", objToJSON, METH_VARARGS | METH_KEYWORDS,  "Converts arbitrary object recursivly into JSON. Use ensure_ascii=false to output UTF-8"},
 	{"loads", JSONToObj, METH_O,  "Converts JSON as string to dict object structure"},


### PR DESCRIPTION
This maintains the 5 decimal place default unless a kwarg was passed in (ideally, we'd just have it default to 9 for our purposes, but I maintained it as 5 in case there are dependencies on your end that rely on the 5 decimal place default)
