### PR TITLE
Proposed change to serializing unknown types

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -582,9 +582,11 @@ ISITERABLE:
 			return;
 		}
 
-		// NOTE: recursive call
+		// NOTE: recursive call to Object_beginTypeContext
+		Py_DECREF(*obj);
 		*obj = jsonDefaultResult;
 		Object_beginTypeContext(obj, tc);
+
 		return;
 	}
 

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -678,15 +678,8 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 	PyObject *newobj;
 	PyObject *oinput = NULL;
 	PyObject *oensureAscii = NULL;
-	int idoublePrecision = 5; // default double precision setting
-
-	PRINTMARK();
-
-	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Oi", kwlist, &oinput, &oensureAscii, &idoublePrecision))
-	{
-		return NULL;
-	}
-
+	const int DEFAULT_DOUBLE_PRECISION = 5;
+	int idoublePrecision = DEFAULT_DOUBLE_PRECISION; 
 	JSONObjectEncoder encoder = 
 	{
 		Object_beginTypeContext,	//void (*beginTypeContext)(JSOBJ obj, JSONTypeContext *tc);
@@ -708,6 +701,16 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 		idoublePrecision,
 		1, //forceAscii
 	};
+
+	PRINTMARK();
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Oi", kwlist, &oinput, &oensureAscii, &idoublePrecision))
+	{
+		return NULL;
+	}
+
+	// iDoublePrecision may have changed if user passed it as a keyword arg
+	encoder.doublePrecision = idoublePrecision;
 	
 	if (oensureAscii != NULL && !PyObject_IsTrue(oensureAscii))
 	{

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,9 +10,9 @@ except(OSError):
 	pass
 
 module1 = Extension('ujson',
-                    sources = ['ujson.c', 'objToJSON.c', 'JSONtoObj.c', 'ultrajsonenc.c', 'ultrajsondec.c'],
+                    sources = ['ujson.c', 'objToJSON.c', 'JSONtoObj.c', '../ultrajsonenc.c', '../ultrajsondec.c'],
                     headers = ['version.h'],
-                    include_dirs = ['./'])
+                    include_dirs = ['.', '..'])
 
 def get_version():
 	filename = os.path.join(os.path.dirname(__file__), 'version.h')

--- a/python/tests.py
+++ b/python/tests.py
@@ -675,6 +675,25 @@ class UltraJSONTests(TestCase):
         dec = ujson.decode(output)
         self.assertEquals(dec, "abcdefg")
 
+    def test_custom_class_with_json_default_nested(self):
+        class N3Class:
+            def json_default(self):
+                return {"key": 31337}
+
+        class N2Class:
+            def json_default(self):
+                return N3Class()
+
+        class N1Class:
+            def json_default(self):
+                return N2Class()
+
+        o = N1Class()
+        output = ujson.encode(o)
+        dec = ujson.decode(output)
+        self.assertEquals(dec["key"], 31337)
+
+
 """
 def test_decodeNumericIntFrcOverflow(self):
 input = "X.Y"

--- a/python/tests.py
+++ b/python/tests.py
@@ -628,17 +628,22 @@ class UltraJSONTests(TestCase):
             input = "\"" + ("\xc3\xa5" * 1024 * 1024 * 10) + "\""
             output = ujson.decode(input)
 
-    def test_toDict(self):
-        d = {u"key": 31337}
-    
-        class DictTest:
-            def toDict(self):
-                return d
-
-        o = DictTest()
+    def test_custom_class_without_json_default(self):
+        class RandomClass:
+            pass
+        o = RandomClass()
         output = ujson.encode(o)
+        self.assertEquals(output, "{}")
+
+    def test_custom_class_with_json_default(self):
+        class RandomClass:
+            def json_default(self):
+                return "abcdefg"
+        o = RandomClass()
+        output = ujson.encode(o)
+        self.assertEquals(output, '"abcdefg"')
         dec = ujson.decode(output)
-        self.assertEquals(dec, d)
+        self.assertEquals(dec, "abcdefg")
 
 """
 def test_decodeNumericIntFrcOverflow(self):

--- a/ultrajson.h
+++ b/ultrajson.h
@@ -168,7 +168,7 @@ typedef void *(*JSPFN_REALLOC)(void *base, size_t size);
 
 typedef struct __JSONObjectEncoder
 {
-	void (*beginTypeContext)(JSOBJ obj, JSONTypeContext *tc);
+	void (*beginTypeContext)(JSOBJ* obj, JSONTypeContext *tc);
 	void (*endTypeContext)(JSOBJ obj, JSONTypeContext *tc);
 	const char *(*getStringValue)(JSOBJ obj, JSONTypeContext *tc, size_t *_outLen);
 	JSINT64 (*getLongValue)(JSOBJ obj, JSONTypeContext *tc);

--- a/ultrajsonenc.c
+++ b/ultrajsonenc.c
@@ -654,7 +654,9 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
 #endif
 	}
 
-	enc->beginTypeContext(obj, &tc);
+	// NOTE: the object pointed to by obj can be changed by beginTypeContext if the 
+	// object can't be natively serialized but it does expose a json_default method
+	enc->beginTypeContext(&obj, &tc);
 
 	switch (tc.type)
 	{


### PR DESCRIPTION
Previously, if an unknown datatype was encountered ujson would look for a toDict method which was required to return a Python dict. I'm proposing a change to make this more general. Now ujson will look for a json_default method instead. If this method returns a json-serializable type, it is serialized directly. Otherwise, ujson will query the returned object for a json_default method, and so on recursively.

An example use case for this is serializing instances of a  bitarray class (http://pypi.python.org/pypi/bitarray). Instances of this class have a natural representation as a string of 0s and 1s. 

The ujson patch allows this:

``` python
from bitarray import bitarray
class mybitarray(bitarray):
    def json_default(self):
        return self.to01()
```

and then mybitarray array instances are serialized as strings

(I also updated the former toDict test cases)
