### PR TITLE
Added 'default' decoder to ujson.dumps

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -65,6 +65,28 @@ def yajlDec():
 
 """=========================================================================="""
 
+def ujsonEncDefault(default):
+    x = ujson.encode(testObject, ensure_ascii=False, default=default)
+    #print "ujsonEnc", x
+
+def simplejsonEncDefault(default):
+    x = simplejson.dumps(testObject, default=default)
+    #print "simplejsonEnc", x
+
+def jsonEncDefault(default):
+    x = json.dumps(testObject, default=default)
+    #print "jsonEnc", x
+
+def cjsonEncDefault(default):
+    x = cjson.encode(testObject, default=default)
+    #print "cjsonEnc", x
+
+def yajlEncDefault():
+    x = yajl.dumps(testObject, default=default)
+    #print "cjsonEnc", x
+
+"""=========================================================================="""
+
 def timeit_compat_fix(timeit):
     if sys.version_info[:2] >=  (2,6):
         return
@@ -235,3 +257,26 @@ print "cjson decode      : %.05f calls/sec" % (COUNT / min(timeit.repeat("cjsonD
 print "simplejson decode : %.05f calls/sec" % (COUNT / min(timeit.repeat("simplejsonDec()", "from __main__ import simplejsonDec", gettime,10, COUNT)), )
 print "yajl decode       : %.05f calls/sec" % (COUNT / min(timeit.repeat("yajlDec()", "from __main__ import yajlDec", gettime,10, COUNT)), )
 
+
+print "Simple object using 'default' serializer:"
+def dictify(obj):
+    try:
+        return obj.__dict__
+    except:
+        pass
+    return obj
+
+class TestOb(object):
+    rickroll = []
+    def __init__(self):
+        for x in xrange(0, 1000):
+            self.rickroll.append("never gonna give you up")
+
+testObject = TestOb()
+
+COUNT = 100000
+
+print "ujson encode      : %.05f calls/sec" % (COUNT / min(timeit.repeat("ujsonEncDefault(dictify)", "from __main__ import ujsonEncDefault, dictify", gettime,10, COUNT)), )
+print "simplejson encode : %.05f calls/sec" % (COUNT / min(timeit.repeat("simplejsonEncDefault(dictify)", "from __main__ import simplejsonEncDefault, dictify", gettime,10, COUNT)), )
+#print "cjson encode      : %.05f calls/sec" % (COUNT / min(timeit.repeat("cjsonEncDefault(dictify)", "from __main__ import cjsonEncDefault, dictify", gettime, 10, COUNT)), )
+#print "yajl  encode      : %.05f calls/sec" % (COUNT / min(timeit.repeat("yajlEncDefault(dictify)", "from __main__ import yajlEncDefault, dictify", gettime, 10, COUNT)), )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -670,6 +670,27 @@ class UltraJSONTests(TestCase):
         dec = ujson.decode(output)
         self.assertEquals(dec, d)
 
+    def test_defaultDecoder(self):
+        class SimpleObj:
+            def __init__(self, s=None, i=None):
+                if s:
+                    self.s = s
+                if i:
+                    self.i = i
+
+            def __eq__(self, other):
+                return self.s == other.s and self.i == other.i
+
+            def toDict(self, obj):
+                return obj.__dict__
+
+        o = SimpleObj({"oscar": "grouch"}, 123)
+        output = ujson.dumps(o, default=o.toDict)
+        dec = ujson.loads(output)
+        n = SimpleObj()
+        n.__dict__ = dec
+        self.assertEquals(n, o)
+
 """
 def test_decodeNumericIntFrcOverflow(self):
 input = "X.Y"


### PR DESCRIPTION
Hi,

This series of patches adds the `default` option to ujson.dumps.

You're probably already aware that in other libraries the default option allows you to provide a function to have objects decoded by prior to serialization. eg.

```
>>> import json
>>> class Message(object):
...     msg = ''
...     def __init__(self, msg):
...         self.msg = msg
... 
>>> m = Message('test')
>>> json.dumps(m)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 201, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 264, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python2.7/json/encoder.py", line 178, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <__main__.Message object at 0xf5b3d0> is not JSON serializable
>>> json.dumps(m, default=lambda x: x.__dict__)
'{"msg": "test"}'
```

ujson already handles this particular object natively. Programmers who wish to decode their own objects (for whatever reason) do not get the convenience of `default` with ujson currently. This is more problematic for other libraries which support multiple json implementations and rely on this feature being available. Hence this request originated from work on the ZeroMQ python bindings. https://github.com/zeromq/pyzmq/pull/188

I have included the patch, benchmark and unit tests in separate commits for convenience.
