### PR TITLE
Add MANIFEST.in to package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README
+include MANIFEST.in
 include setup.y
 include tests/*.py
 include tests/*.json


### PR DESCRIPTION
Without MANIFEST.in included in the tarball, RPM's of ultrajson can't be built. This patch add's MANIFEST.in.
