### PR TITLE
Auto skip trailing whitespace and carriage return, instead of raising 'ValueError: Trailing data'.

### DIFF
--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -830,12 +830,6 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds)
     }
 }
 
-static void skip_whitespace_and_carriage_return(struct DecoderState *ds)
-{
-    while (ds->start != ds->end && (*ds->start == '\n' || *ds->start == ' '))
-        ds->start ++;
-}
-
 JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuffer)
 {
 
@@ -864,7 +858,7 @@ JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuf
         dec->free(ds.escStart);
     }
 
-    skip_whitespace_and_carriage_return(&ds);
+    SkipWhitespace(&ds);
 
     if (ds.start != ds.end && ret)
     {

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -810,7 +810,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds)
             case '-': 
                 return decode_numeric (ds);
 
-            case '[':   return decode_array (ds);
+            case '[': return decode_array (ds);
             case '{': return decode_object (ds);
             case 't': return decode_true (ds);
             case 'f': return decode_false (ds);
@@ -830,6 +830,11 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_any(struct DecoderState *ds)
     }
 }
 
+static void skip_whitespace_and_carriage_return(struct DecoderState *ds)
+{
+    while (ds->start != ds->end && (*ds->start == '\n' || *ds->start == ' '))
+        ds->start ++;
+}
 
 JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuffer)
 {
@@ -858,6 +863,8 @@ JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuf
     {
         dec->free(ds.escStart);
     }
+
+    skip_whitespace_and_carriage_return(&ds);
 
     if (ds.start != ds.end && ret)
     {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -788,7 +788,20 @@ class UltraJSONTests(TestCase):
             pass
         else:
             assert False, "expected ValueError"       
-        
+
+    def test_decodeWithTrailingWhitespaces(self):
+        input = "{}\n\t "
+        ujson.decode(input)
+
+    def test_decodeWithTrailingNonWhitespaces(self):
+        try:
+            input = "{}\n\t a"
+            ujson.decode(input)
+        except ValueError:
+            pass
+        else:
+            assert False, "expected ValueError"
+
 """
 def test_decodeNumericIntFrcOverflow(self):
 input = "X.Y"


### PR DESCRIPTION
Made ujson behavior in conformance with built-in json lib.
