### PR TITLE
Cannot build ujson via pip on CentOS 5.8 x86_64 with Python 2.7.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ module1 = Extension('ujson',
                                './python/JSONtoObj.c', 
                                './lib/ultrajsonenc.c', 
                                './lib/ultrajsondec.c'],
-                    include_dirs = ['./python', './lib'])
+                    include_dirs = ['./python', './lib']
+                    extra_compile_args=['-D_GNU_SOURCE'])
 
 def get_version():
     filename = os.path.join(os.path.dirname(__file__), './python/version.h')


### PR DESCRIPTION
Seeing these errors:

./lib/ultrajsondec.c: In function ‘decode_numeric’:

./lib/ultrajsondec.c:93: error: ‘LLONG_MAX’ undeclared (first use in this function)

./lib/ultrajsondec.c:93: error: (Each undeclared identifier is reported only once

./lib/ultrajsondec.c:93: error: for each function it appears in.)

./lib/ultrajsondec.c:99: error: ‘LLONG_MIN’ undeclared (first use in this function)

...

then:

error: command 'gcc' failed with exit status 1

Any ideas?
