### PR TITLE
Support optional unicode escaping of <, >, and & characters

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -223,6 +223,9 @@ typedef struct __JSONObjectEncoder
     If true output will be ASCII with all characters above 127 encoded as \uXXXX. If false output will be UTF-8 or what ever charset strings are brought as */
     int forceASCII;
 
+    /*
+    If true, '<', '>', and '&' characters will be encoded as \u003c, \u003e, and \u0026, respectively. If false, no special encoding will be used. */
+    int encodeHTMLChars;
 
     /*
     Set to an error message if error occured */

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -800,7 +800,7 @@ char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 
 PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 {
-    static char *kwlist[] = { "obj", "ensure_ascii", "double_precision", NULL};
+    static char *kwlist[] = { "obj", "ensure_ascii", "double_precision", "encode_html_chars", NULL };
 
     char buffer[65536];
     char *ret;
@@ -808,6 +808,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     PyObject *oinput = NULL;
     PyObject *oensureAscii = NULL;
     int idoublePrecision = 5; // default double precision setting
+    PyObject *oencodeHTMLChars = NULL;
 
     JSONObjectEncoder encoder = 
     {
@@ -829,12 +830,13 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
         -1, //recursionMax
         idoublePrecision,
         1, //forceAscii
+        0, //encodeHTMLChars
     };
 
 
     PRINTMARK();
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|Oi", kwlist, &oinput, &oensureAscii, &idoublePrecision))
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiO", kwlist, &oinput, &oensureAscii, &idoublePrecision, &oencodeHTMLChars))
     {
         return NULL;
     }
@@ -846,6 +848,11 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     }
 
     encoder.doublePrecision = idoublePrecision;
+
+    if (oencodeHTMLChars != NULL && PyObject_IsTrue(oencodeHTMLChars))
+    {
+        encoder.encodeHTMLChars = 1;
+    }
 
     PRINTMARK();
     ret = JSON_EncodeObject (oinput, &encoder, buffer, sizeof (buffer));

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -107,12 +107,27 @@ class UltraJSONTests(TestCase):
 
 
     def test_encodeStringConversion(self):
-        input = "A string \\ / \b \f \n \r \t"
-        output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, '"A string \\\\ \\/ \\b \\f \\n \\r \\t"')
-        self.assertEquals(input, ujson.decode(output))
-        pass
+        input = "A string \\ / \b \f \n \r \t </script> &"
+        not_html_encoded = '"A string \\\\ \\/ \\b \\f \\n \\r \\t <\\/script> &"'
+        html_encoded = '"A string \\\\ \\/ \\b \\f \\n \\r \\t \\u003c\\/script\\u003e \\u0026"'
+
+        def helper(expected_output, **encode_kwargs):
+            output = ujson.encode(input, **encode_kwargs)
+            self.assertEquals(input, json.loads(output))
+            self.assertEquals(output, expected_output)
+            self.assertEquals(input, ujson.decode(output))
+
+        # Default behavior assumes encode_html_chars=False.
+        helper(not_html_encoded, ensure_ascii=True)
+        helper(not_html_encoded, ensure_ascii=False)
+
+        # Make sure explicit encode_html_chars=False works.
+        helper(not_html_encoded, ensure_ascii=True, encode_html_chars=False)
+        helper(not_html_encoded, ensure_ascii=False, encode_html_chars=False)
+
+        # Make sure explicit encode_html_chars=True does the encoding.
+        helper(html_encoded, ensure_ascii=True, encode_html_chars=True)
+        helper(html_encoded, ensure_ascii=False, encode_html_chars=True)
 
     def test_decodeUnicodeConversion(self):
         pass


### PR DESCRIPTION
This pull request improves on https://github.com/esnme/ultrajson/pull/70 (which I will close).

The default is not to do any special escaping.

Pass encode_html_chars=True to ujson.encode to enable escaping.

Conditional logic is used only when <, >, or & characters are encountered, so there should be zero additional overhead for strings without any of those characters.

If you like this approach, great! If not, I don't want to keep wasting your time, and I will find another way to solve my problems.
