### PR TITLE
String deduplication

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -271,6 +271,8 @@ typedef struct __JSONObjectDecoder
 {
 	JSOBJ (*newString)(wchar_t *start, wchar_t *end);
 	void (*objectAddKey)(JSOBJ obj, JSOBJ name, JSOBJ value);
+	JSOBJ (*objectLookupKey)(JSOBJ obj, JSOBJ name);
+	JSOBJ (*objectClear)(JSOBJ obj);
 	void (*arrayAddItem)(JSOBJ obj, JSOBJ value);
 	JSOBJ (*newTrue)(void);
 	JSOBJ (*newFalse)(void);

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -45,9 +45,25 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 void Object_objectAddKey(JSOBJ obj, JSOBJ name, JSOBJ value)
 {
     PyDict_SetItem (obj, name, value);
-    Py_DECREF( (PyObject *) name);
-    Py_DECREF( (PyObject *) value);
+    if (name != value) {
+        Py_DECREF( (PyObject *) name);
+        Py_DECREF( (PyObject *) value);
+    }
     return;
+}
+
+JSOBJ Object_objectLookupKey(JSOBJ obj, JSOBJ name)
+{
+    PyObject *val = PyDict_GetItem (obj, name);
+    if (val == NULL) return;
+    Py_INCREF( (PyObject *) val);
+    Py_DECREF( (PyObject *) name);
+    return val;
+}
+
+JSOBJ Object_objectClear(JSOBJ obj)
+{
+    PyDict_Clear (obj);
 }
 
 void Object_arrayAddItem(JSOBJ obj, JSOBJ value)
@@ -119,6 +135,8 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     {
         Object_newString,
         Object_objectAddKey,
+        Object_objectLookupKey,
+        Object_objectClear,
         Object_arrayAddItem,
         Object_newTrue,
         Object_newFalse,


### PR DESCRIPTION
I use a temporary (Python) dictionary object to deduplicate strings in JSON input. Implementation is simple, utilizing Python's own dictionary object. This could be optimized, but it works pretty well as it is. The effect on memory usage is similar to string interning.
