### PR TITLE
Make idoublePrecision a true constant

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -802,7 +802,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *newobj;
   PyObject *oinput = NULL;
   PyObject *oensureAscii = NULL;
-  int idoublePrecision = 10; // default double precision setting
+  static const int idoublePrecision = 10; // default double precision setting
   PyObject *oencodeHTMLChars = NULL;
 
   JSONObjectEncoder encoder =


### PR DESCRIPTION
Some older compilers might complain about idoublePrecision not being a constant when referenced inside the array declaration.
