### PR TITLE
Silence warning about unused PyIntToINTXX

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -96,19 +96,21 @@ void initObjToJSON(void)
   PyDateTime_IMPORT;
 }
 
-static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
-{
-  PyObject *obj = (PyObject *) _obj;
-  *((JSINT32 *) outValue) = PyInt_AS_LONG (obj);
-  return NULL;
-}
-
+#ifdef _LP64
 static void *PyIntToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
   PyObject *obj = (PyObject *) _obj;
   *((JSINT64 *) outValue) = PyInt_AS_LONG (obj);
   return NULL;
 }
+#else
+static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
+{
+  PyObject *obj = (PyObject *) _obj;
+  *((JSINT32 *) outValue) = PyInt_AS_LONG (obj);
+  return NULL;
+}
+#endif
 
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {


### PR DESCRIPTION
Make the declaration of PyIntToINT32/PyIntToINT64 conditional; otherwise the compiler always warns about one of them being unused.
