### PR TITLE
add possibility to encode Iterable objects

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -809,7 +809,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *newobj;
   PyObject *oinput = NULL;
   PyObject *oensureAscii = NULL;
-  PyObject *doublePrecision = NULL;
+  short int idoublePrecision = 10;
   PyObject *oencodeHTMLChars = NULL;
 
   JSONObjectEncoder encoder =
@@ -838,7 +838,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 
   PRINTMARK();
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOO", kwlist, &oinput, &oensureAscii, &doublePrecision, &oencodeHTMLChars))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OhO", kwlist, &oinput, &oensureAscii, &idoublePrecision, &oencodeHTMLChars))
   {
     return NULL;
   }
@@ -852,17 +852,8 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   {
     encoder.encodeHTMLChars = 1;
   }
-  if (doublePrecision)
-  {
-    PRINTMARK();
-    if (!PyInt_Check(lifetime))
-    {
-      PRINTMARK();
-      PyErr_Format(PyExc_TypeError, "Expected integer as double_precision paramater.");
-      return NULL;
-    }
-    encoder.doublePrecision = (int)(PyInt_AS_LONG(doublePrecision));
-  }
+
+  encoder.doublePrecision = idoublePrecision;
 
   PRINTMARK();
   ret = JSON_EncodeObject (oinput, &encoder, buffer, sizeof (buffer));

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -854,7 +854,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   }
   if (doublePrecision)
   {
-	encoder.doublePrecision = (int)(PyInt_AS_LONG(doublePrecision));
+    encoder.doublePrecision = (int)(PyInt_AS_LONG(doublePrecision));
   }
 
   PRINTMARK();

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -544,12 +544,6 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
   pc->size = 0;
   pc->longValue = 0;
 
-  if (PyIter_Check(obj))
-  {
-    PRINTMARK();
-    goto ISITERABLE;
-  }
-
   if (PyBool_Check(obj))
   {
     PRINTMARK();
@@ -627,8 +621,7 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
     tc->type = JT_NULL;
     return;
   }
-
-ISITERABLE:
+  else
   if (PyDict_Check(obj))
   {
     PRINTMARK();
@@ -677,6 +670,18 @@ ISITERABLE:
     pc->iterGetValue = Iter_iterGetValue;
     pc->iterGetName = Iter_iterGetName;
     return;
+  }
+  else
+  if (PyIter_Check(obj))
+  {
+		PRINTMARK();
+		tc->type = JT_ARRAY;
+		pc->iterBegin = Iter_iterBegin;
+		pc->iterEnd = Iter_iterEnd;
+		pc->iterNext = Iter_iterNext;
+		pc->iterGetValue = Iter_iterGetValue;
+		pc->iterGetName = Iter_iterGetName;
+		return;
   }
 
   toDictFunc = PyObject_GetAttrString(obj, "toDict");
@@ -804,7 +809,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *newobj;
   PyObject *oinput = NULL;
   PyObject *oensureAscii = NULL;
-  static const int idoublePrecision = 10; // default double precision setting
+  PyObject *doublePrecision = NULL;
   PyObject *oencodeHTMLChars = NULL;
 
   JSONObjectEncoder encoder =
@@ -825,7 +830,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     PyObject_Realloc,
     PyObject_Free,
     -1, //recursionMax
-    idoublePrecision,
+    10, //doublePrecision,
     1, //forceAscii
     0, //encodeHTMLChars
   };
@@ -833,7 +838,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 
   PRINTMARK();
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OiO", kwlist, &oinput, &oensureAscii, &idoublePrecision, &oencodeHTMLChars))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOO", kwlist, &oinput, &oensureAscii, &doublePrecision, &oencodeHTMLChars))
   {
     return NULL;
   }
@@ -847,8 +852,10 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   {
     encoder.encodeHTMLChars = 1;
   }
-
-  encoder.doublePrecision = idoublePrecision;
+  if (doublePrecision)
+  {
+	encoder.doublePrecision = (int)(PyInt_AS_LONG(doublePrecision));
+  }
 
   PRINTMARK();
   ret = JSON_EncodeObject (oinput, &encoder, buffer, sizeof (buffer));

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -854,6 +854,13 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   }
   if (doublePrecision)
   {
+    PRINTMARK();
+    if (!PyInt_Check(lifetime))
+    {
+      PRINTMARK();
+      PyErr_Format(PyExc_TypeError, "Expected integer as double_precision paramater.");
+      return NULL;
+    }
     encoder.doublePrecision = (int)(PyInt_AS_LONG(doublePrecision));
   }
 

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -674,14 +674,14 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
   else
   if (PyIter_Check(obj))
   {
-		PRINTMARK();
-		tc->type = JT_ARRAY;
-		pc->iterBegin = Iter_iterBegin;
-		pc->iterEnd = Iter_iterEnd;
-		pc->iterNext = Iter_iterNext;
-		pc->iterGetValue = Iter_iterGetValue;
-		pc->iterGetName = Iter_iterGetName;
-		return;
+    PRINTMARK();
+    tc->type = JT_ARRAY;
+    pc->iterBegin = Iter_iterBegin;
+    pc->iterEnd = Iter_iterEnd;
+    pc->iterNext = Iter_iterNext;
+    pc->iterGetValue = Iter_iterGetValue;
+    pc->iterGetName = Iter_iterGetName;
+    return;
   }
 
   toDictFunc = PyObject_GetAttrString(obj, "toDict");


### PR DESCRIPTION
tests are pass.
in addition fixed crash in python3 x86_64 if option double_precision was specified.
