### PR TITLE
support unsigned uint64 for ultrajson

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -150,6 +150,7 @@ enum JSTYPES
   JT_FALSE,       //boolean false
   JT_INT,         //(JSINT32 (signed 32-bit))
   JT_LONG,        //(JSINT64 (signed 64-bit))
+  JT_ULONG,       //(JSUINT64 (unsigned 64-bit))
   JT_DOUBLE,    //(double)
   JT_UTF8,        //(char 8-bit)
   JT_ARRAY,       // Array structure
@@ -183,6 +184,7 @@ typedef struct __JSONObjectEncoder
   void (*endTypeContext)(JSOBJ obj, JSONTypeContext *tc);
   const char *(*getStringValue)(JSOBJ obj, JSONTypeContext *tc, size_t *_outLen);
   JSINT64 (*getLongValue)(JSOBJ obj, JSONTypeContext *tc);
+  JSUINT64 (*getULongValue)(JSOBJ obj, JSONTypeContext *tc);
   JSINT32 (*getIntValue)(JSOBJ obj, JSONTypeContext *tc);
   double (*getDoubleValue)(JSOBJ obj, JSONTypeContext *tc);
 
@@ -294,6 +296,7 @@ typedef struct __JSONObjectDecoder
   JSOBJ (*newArray)(void *prv);
   JSOBJ (*newInt)(void *prv, JSINT32 value);
   JSOBJ (*newLong)(void *prv, JSINT64 value);
+  JSOBJ (*newULong)(void *prv, JSUINT64 value);
   JSOBJ (*newDouble)(void *prv, double value);
   void (*releaseObject)(void *prv, JSOBJ obj);
   JSPFN_MALLOC malloc;

--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -52,6 +52,7 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #define NULL 0
 #endif
 
+#define CHK_OVERFLOW
 struct DecoderState
 {
   char *start;
@@ -103,6 +104,9 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_numeric (struct DecoderState *ds)
   int intNeg = 1;
   int mantSize = 0;
   JSUINT64 intValue;
+#ifdef CHK_OVERFLOW
+  JSUINT64 newValue;
+#endif
   int chr;
   int decimalCount = 0;
   double frcValue = 0.0;
@@ -139,14 +143,28 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_numeric (struct DecoderState *ds)
       case '8':
       case '9':
       {
-        //FIXME: Check for arithemtic overflow here
-        //PERF: Don't do 64-bit arithmetic here unless we know we have to
+#ifdef CHK_OVERFLOW
+	newValue = intValue * 10ULL;
+	if(!intValue || newValue / intValue == 10ULL)
+	{
+		intValue = newValue;
+		newValue = intValue + (JSLONG)(chr - 48);
+		if(newValue < intValue)
+		{
+			return SetError(ds, -1, "arithemtic overflow");
+		}
+		else
+		{
+			intValue = newValue;
+		}
+	}
+	else
+	{
+		return SetError(ds, -1, "arithemtic overflow");
+	}
+#else
         intValue = intValue * 10ULL + (JSLONG) (chr - 48);
-
-        if (intValue > overflowLimit)
-        {
-          return SetError(ds, -1, overflowLimit == LLONG_MAX ? "Value is too big" : "Value is too small");
-        }
+#endif
 
         offset ++;
         mantSize ++;
@@ -181,7 +199,15 @@ BREAK_INT_LOOP:
 
   if ((intValue >> 31))
   {
-    return ds->dec->newLong(ds->prv, (JSINT64) (intValue * (JSINT64) intNeg));
+	if(intNeg == 1)
+	{
+    		return ds->dec->newULong(ds->prv, intValue);
+	}
+	else if(intNeg == -1)
+	{
+
+    		return ds->dec->newLong(ds->prv, (JSINT64) (intValue * (JSINT64) intNeg));
+	}
   }
   else
   {

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -509,6 +509,21 @@ void Buffer_AppendLongUnchecked(JSONObjectEncoder *enc, JSINT64 value)
   enc->offset += (wstr - (enc->offset));
 }
 
+void Buffer_AppendULongUnchecked(JSONObjectEncoder *enc, JSUINT64 value)
+{
+  char* wstr;
+  JSUINT64 uvalue = value;
+
+  wstr = enc->offset;
+  // Conversion. Number is reversed.
+
+  do *wstr++ = (char)(48 + (uvalue % 10ULL)); while(uvalue /= 10ULL);
+
+  // Reverse string
+  strreverse(enc->offset,wstr - 1);
+  enc->offset += (wstr - (enc->offset));
+}
+
 int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc, double value)
 {
   /* if input is larger than thres_max, revert to exponential */
@@ -786,6 +801,11 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
     break;
   }
 
+  case JT_ULONG:
+  {
+    Buffer_AppendULongUnchecked (enc, enc->getULongValue(obj, &tc));
+    break;
+  }
   case JT_INT:
   {
     Buffer_AppendIntUnchecked (enc, enc->getIntValue(obj, &tc));

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -97,6 +97,11 @@ JSOBJ Object_newLong(void *prv, JSINT64 value)
   return PyLong_FromLongLong (value);
 }
 
+JSOBJ Object_newULong(void *prv, JSUINT64 value)
+{
+  return PyLong_FromUnsignedLongLong(value);
+}
+
 JSOBJ Object_newDouble(void *prv, double value)
 {
   return PyFloat_FromDouble(value);
@@ -127,6 +132,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_newArray,
     Object_newInteger,
     Object_newLong,
+    Object_newULong,
     Object_newDouble,
     Object_releaseObject,
     PyObject_Malloc,


### PR DESCRIPTION
in general linux distributed system. UUID or GUID is unsigned int64 type. 
I strongly suggest author to merge this request. 
It has been test wildly in my previous project.

I add a new type JT_ULONG to represent unsigned uint64 to the enums JSTYPES and add a function pointer getULongValue to struct _JSONObjectEncoder 

when encoding a Pytheon Number to a C number in function Object_beginTypeContext in objToJson.c , I try twice to see if the number can be  converted to a c unsigned int64(see lines 579 to 592 in file objToJson.c)

it is more difficult to decode a string to an unsigned int64 with arithemtic overflow check. but I find a theory in <<CSAPP>> to do this.
/\* Determine whether arguments can be added without overflow */ 
int uadd_ok(unsigned int x, unsigned int y) 
{ 
return !(x+y < x); 
} 

/\* Determine whether arguments can be multiplied without overflow */ 
int umul_ok(unsigned int x, unsigned int y) 
{ 
unsigned int p = x \* y; 
return !x || p/x==y; 
} 
