### PR TITLE
Added support for cdecimal encoding

### DIFF
--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -154,11 +154,10 @@ static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue, si
   return PyString_AS_STRING(newObj);
 }
 
-static void *PyDateTimeToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
+static void *PyDateTimeToString(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
   PyObject *obj = (PyObject *) _obj;
-  PyObject *date, *ord;
-  int y, m, d, h, mn, s, days;
+  int y, m, d, h, mn, s;
 
   y = PyDateTime_GET_YEAR(obj);
   m = PyDateTime_GET_MONTH(obj);
@@ -167,13 +166,10 @@ static void *PyDateTimeToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, 
   mn = PyDateTime_DATE_GET_MINUTE(obj);
   s = PyDateTime_DATE_GET_SECOND(obj);
 
-  date = PyDate_FromDate(y, m, 1);
-  ord = PyObject_CallMethod(date, "toordinal", NULL);
-  days = PyInt_AS_LONG(ord) - EPOCH_ORD + d - 1;
-  Py_DECREF(date);
-  Py_DECREF(ord);
-  *( (JSINT64 *) outValue) = (((JSINT64) ((days * 24 + h) * 60 + mn)) * 60 + s);
-  return NULL;
+  char str[20];
+  sprintf(str, "%04d-%02d-%02d %02d:%02d:%02d", y, m, d, h, mn, s);
+  *_outLen = strlen(str);
+  return str;
 }
 
 static void *PyDateToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
@@ -621,7 +617,7 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
   if (PyDateTime_Check(obj))
   {
     PRINTMARK();
-    pc->PyTypeToJSON = PyDateTimeToINT64; tc->type = JT_LONG;
+    pc->PyTypeToJSON = PyDateTimeToString; tc->type = JT_UTF8;
     return;
   }
   else

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -42,6 +42,7 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 
 #define EPOCH_ORD 719163
 static PyObject* type_decimal = NULL;
+static PyObject* type_cdecimal = NULL;
 
 typedef void *(*PFN_PyTypeToJSON)(JSOBJ obj, JSONTypeContext *ti, void *outValue, size_t *_outLen);
 
@@ -89,6 +90,16 @@ void initObjToJSON(void)
     type_decimal = PyObject_GetAttrString(mod_decimal, "Decimal");
     Py_INCREF(type_decimal);
     Py_DECREF(mod_decimal);
+  }
+  else
+    PyErr_Clear();
+
+  PyObject* mod_cdecimal = PyImport_ImportModule("cdecimal");
+  if (mod_cdecimal)
+  {
+    type_cdecimal = PyObject_GetAttrString(mod_cdecimal, "Decimal");
+    Py_INCREF(type_cdecimal);
+    Py_DECREF(mod_cdecimal);    
   }
   else
     PyErr_Clear();
@@ -600,7 +611,7 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
     return;
   }
   else
-  if (PyFloat_Check(obj) || (type_decimal && PyObject_IsInstance(obj, type_decimal)))
+  if (PyFloat_Check(obj) || (type_decimal && PyObject_IsInstance(obj, type_decimal)) || (type_cdecimal && PyObject_IsInstance(obj, type_cdecimal)))
   {
     PRINTMARK();
     pc->PyTypeToJSON = PyFloatToDOUBLE; tc->type = JT_DOUBLE;

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -20,6 +20,7 @@ import StringIO
 import re
 import random
 import decimal
+import cdecimal
 from functools import partial
 
 PY3 = (sys.version_info[0] >= 3)
@@ -35,6 +36,12 @@ class UltraJSONTests(TestCase):
 
     def test_encodeDecimal(self):
         sut = decimal.Decimal("1337.1337")
+        encoded = ujson.encode(sut, double_precision=100)
+        decoded = ujson.decode(encoded)
+        self.assertEquals(decoded, 1337.1337)
+
+    def test_encodeCDecimal(self):
+        sut = cdecimal.Decimal("1337.1337")
         encoded = ujson.encode(sut, double_precision=100)
         decoded = ujson.decode(encoded)
         self.assertEquals(decoded, 1337.1337)


### PR DESCRIPTION
The cdecimal module is faster than the decimal library in many cases. I saw multiple people asking for this in this [pull request](https://github.com/esnme/ultrajson/pull/38) so here it is.
