### PR TITLE
toJson method

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -155,6 +155,7 @@ enum JSTYPES
   JT_ARRAY,       // Array structure
   JT_OBJECT,    // Key/Value structure
   JT_INVALID,    // Internal, do not return nor expect
+  JT_JSON,      //Raw JSON
 };
 
 typedef void * JSOBJ;

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -721,6 +721,21 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
         return;
       }
 
+      case JT_JSON:
+      {
+        value = enc->getStringValue(obj, &tc, &szlen);
+        Buffer_Reserve(enc, szlen);
+        if (enc->errorMsg)
+        {
+          enc->endTypeContext(obj, &tc);
+          return;
+        }
+
+        memcpy(enc->offset, value, szlen);
+        enc->offset += szlen;
+        break;
+      }
+
       case JT_ARRAY:
       {
         count = 0;

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -802,6 +802,19 @@ class UltraJSONTests(TestCase):
         dec = ujson.decode(output)
         self.assertEquals(dec, d)
 
+    def test_toJson(self):
+        d = {u"key": 31337}
+        json = ujson.encode(d)
+
+        class AlreadyJson:
+            def toJson(self):
+                return json
+
+        o = AlreadyJson()
+        output = ujson.encode(o)
+        dec = ujson.decode(output)
+        self.assertEquals(dec, d)
+
     def test_decodeArrayTrailingCommaFail(self):
         input = "[31337,]"
         try:


### PR DESCRIPTION
This change added a toJson method that operates similarly to toDict during encode. The difference is that the result of toJson is treated as a string containing pure JSON that is inserted into the output buffer.

I had a use for this feature when serializing a large rapidly dictionary structure that had a number of complex, but unchanging sub-elements. Especially since I would store a number of those immutable sub-elements as JSON already to reduce memory usage (single string vs dictionary) this saved me both a decode and encode operation that I would have otherwise had to do if I only used toDict.
