### PR TITLE
Support values between [0, 2^64 - 1]

### DIFF
--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -146,16 +146,17 @@ typedef int64_t JSLONG;
 
 enum JSTYPES
 {
-  JT_NULL,        // NULL
-  JT_TRUE,        //boolean true
-  JT_FALSE,       //boolean false
-  JT_INT,         //(JSINT32 (signed 32-bit))
-  JT_LONG,        //(JSINT64 (signed 64-bit))
-  JT_DOUBLE,    //(double)
-  JT_UTF8,        //(char 8-bit)
-  JT_ARRAY,       // Array structure
+  JT_NULL,      // NULL
+  JT_TRUE,      // boolean true
+  JT_FALSE,     // boolean false
+  JT_INT,       // (JSINT32 (signed 32-bit))
+  JT_LONG,      // (JSINT64 (signed 64-bit))
+  JT_ULONG,     // (JSUINT64 (unsigned 64-bit))
+  JT_DOUBLE,    // (double)
+  JT_UTF8,      // (char 8-bit)
+  JT_ARRAY,     // Array structure
   JT_OBJECT,    // Key/Value structure
-  JT_INVALID,    // Internal, do not return nor expect
+  JT_INVALID,   // Internal, do not return nor expect
 };
 
 typedef void * JSOBJ;
@@ -184,6 +185,7 @@ typedef struct __JSONObjectEncoder
   void (*endTypeContext)(JSOBJ obj, JSONTypeContext *tc);
   const char *(*getStringValue)(JSOBJ obj, JSONTypeContext *tc, size_t *_outLen);
   JSINT64 (*getLongValue)(JSOBJ obj, JSONTypeContext *tc);
+  JSUINT64 (*getUnsignedLongValue)(JSOBJ obj, JSONTypeContext *tc);
   JSINT32 (*getIntValue)(JSOBJ obj, JSONTypeContext *tc);
   double (*getDoubleValue)(JSOBJ obj, JSONTypeContext *tc);
 

--- a/lib/ultrajson.h
+++ b/lib/ultrajson.h
@@ -293,6 +293,7 @@ typedef struct __JSONObjectDecoder
   JSOBJ (*newArray)(void *prv);
   JSOBJ (*newInt)(void *prv, JSINT32 value);
   JSOBJ (*newLong)(void *prv, JSINT64 value);
+  JSOBJ (*newUnsignedLong)(void *prv, JSUINT64 value);
   JSOBJ (*newDouble)(void *prv, double value);
   void (*releaseObject)(void *prv, JSOBJ obj);
   JSPFN_MALLOC malloc;

--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -510,6 +510,21 @@ void Buffer_AppendLongUnchecked(JSONObjectEncoder *enc, JSINT64 value)
   enc->offset += (wstr - (enc->offset));
 }
 
+void Buffer_AppendUnsignedLongUnchecked(JSONObjectEncoder *enc, JSUINT64 value)
+{
+  char* wstr;
+  JSUINT64 uvalue = value;
+
+  wstr = enc->offset;
+  // Conversion. Number is reversed.
+
+  do *wstr++ = (char)(48 + (uvalue % 10ULL)); while(uvalue /= 10ULL);
+
+  // Reverse string
+  strreverse(enc->offset,wstr - 1);
+  enc->offset += (wstr - (enc->offset));
+}
+
 int Buffer_AppendDoubleUnchecked(JSOBJ obj, JSONObjectEncoder *enc, double value)
 {
   /* if input is larger than thres_max, revert to exponential */
@@ -783,6 +798,12 @@ void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t cbName)
   case JT_LONG:
   {
     Buffer_AppendLongUnchecked (enc, enc->getLongValue(obj, &tc));
+    break;
+  }
+
+  case JT_ULONG:
+  {
+    Buffer_AppendUnsignedLongUnchecked (enc, enc->getUnsignedLongValue(obj, &tc));
     break;
   }
 

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -98,6 +98,11 @@ JSOBJ Object_newLong(void *prv, JSINT64 value)
   return PyLong_FromLongLong (value);
 }
 
+JSOBJ Object_newUnsignedLong(void *prv, JSUINT64 value)
+{
+  return PyLong_FromUnsignedLongLong (value);
+}
+
 JSOBJ Object_newDouble(void *prv, double value)
 {
   return PyFloat_FromDouble(value);
@@ -128,6 +133,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_newArray,
     Object_newInteger,
     Object_newLong,
+    Object_newUnsignedLong,
     Object_newDouble,
     Object_releaseObject,
     PyObject_Malloc,

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -66,7 +66,11 @@ typedef struct __TypeContext
   PyObject *attrList;
   PyObject *iterator;
 
-  JSINT64 longValue;
+  union
+  {
+    JSINT64 longValue;
+    JSUINT64 unsignedLongValue;
+  };
 } TypeContext;
 
 #define GET_TC(__ptrtc) ((TypeContext *)((__ptrtc)->prv))
@@ -115,6 +119,12 @@ static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
   *((JSINT64 *) outValue) = GET_TC(tc)->longValue;
+  return NULL;
+}
+
+static void *PyLongToUINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
+{
+  *((JSUINT64 *) outValue) = GET_TC(tc)->unsignedLongValue;
   return NULL;
 }
 
@@ -531,11 +541,24 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
     GET_TC(tc)->longValue = PyLong_AsLongLong(obj);
 
     exc = PyErr_Occurred();
+    if (!exc)
+    {
+        return;
+    }
 
     if (exc && PyErr_ExceptionMatches(PyExc_OverflowError))
     {
-      PRINTMARK();
-      goto INVALID;
+      PyErr_Clear();
+      pc->PyTypeToJSON = PyLongToUINT64;
+      tc->type = JT_ULONG;
+      GET_TC(tc)->unsignedLongValue = PyLong_AsUnsignedLongLong(obj);
+
+      exc = PyErr_Occurred();
+      if (exc && PyErr_ExceptionMatches(PyExc_OverflowError))
+      {
+        PRINTMARK();
+        goto INVALID;
+      }
     }
 
     return;
@@ -743,6 +766,13 @@ JSINT64 Object_getLongValue(JSOBJ obj, JSONTypeContext *tc)
   return ret;
 }
 
+JSUINT64 Object_getUnsignedLongValue(JSOBJ obj, JSONTypeContext *tc)
+{
+  JSUINT64 ret;
+  GET_TC(tc)->PyTypeToJSON (obj, tc, &ret, NULL);
+  return ret;
+}
+
 JSINT32 Object_getIntValue(JSOBJ obj, JSONTypeContext *tc)
 {
   JSINT32 ret;
@@ -799,6 +829,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_endTypeContext,
     Object_getStringValue,
     Object_getLongValue,
+    Object_getUnsignedLongValue,
     Object_getIntValue,
     Object_getDoubleValue,
     Object_iterNext,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -857,6 +857,10 @@ class UltraJSONTests(TestCase):
         input = "[31337]"
         ujson.decode(input)
 
+    def test_decodeLongUnsignedValue(self):
+        input = "18446744073709551615"
+        ujson.decode(input)
+
     def test_decodeBigValue(self):
         input = "9223372036854775807"
         ujson.decode(input)
@@ -867,7 +871,7 @@ class UltraJSONTests(TestCase):
 
     def test_decodeTooBigValue(self):
         try:
-            input = "9223372036854775808"
+            input = "18446744073709551616"
             ujson.decode(input)
         except ValueError, e:
             pass
@@ -885,7 +889,7 @@ class UltraJSONTests(TestCase):
 
     def test_decodeVeryTooBigValue(self):
         try:
-            input = "9223372036854775808"
+            input = "18446744073709551616"
             ujson.decode(input)
         except ValueError:
             pass
@@ -916,7 +920,7 @@ class UltraJSONTests(TestCase):
 
     def test_decodeArrayWithBigInt(self):
         try:
-            ujson.loads('[18446098363113800555]')
+            ujson.loads('[18446744073709551616]')
         except ValueError:
             pass
         else:
@@ -924,7 +928,7 @@ class UltraJSONTests(TestCase):
 
     def test_decodeArrayFaultyUnicode(self):
         try:
-            ujson.loads('[18446098363113800555]')
+            ujson.loads('[18446744073709551616]')
         except ValueError:
             pass
         else:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -641,9 +641,24 @@ class UltraJSONTests(TestCase):
         self.assertEquals(input, json.loads(output))
         self.assertEquals(input, ujson.decode(output))
 
+    def test_encodeListLongUnsignedConversion(self):
+        input = [18446744073709551615, 18446744073709551615, 18446744073709551615]
+        output = ujson.encode(input)
+
+        self.assertEquals(input, json.loads(output))
+        self.assertEquals(input, ujson.decode(output))
+
     def test_encodeLongConversion(self):
         input = 9223372036854775807
         output = ujson.encode(input)
+        self.assertEquals(input, json.loads(output))
+        self.assertEquals(output, json.dumps(input))
+        self.assertEquals(input, ujson.decode(output))
+
+    def test_encodeLongUnsignedConversion(self):
+        input = 18446744073709551615
+        output = ujson.encode(input)
+
         self.assertEquals(input, json.loads(output))
         self.assertEquals(output, json.dumps(input))
         self.assertEquals(input, ujson.decode(output))


### PR DESCRIPTION
The current numeric parser behavior will not allow a value of 2^63 because it assumes that all integers will be signed.  This change promotes non-negative numeric values with the most significant bit set to an `unsigned long long` type.

Example of the fix in practice:

``` python
>>> import ujson
>>> ujson.loads('{"id": %d}' % 2**63)
{u'id': 9223372036854775808L}
>>> ujson.loads('{"id": %s}' % 0xFFFFFFFFFFFFFFFFL)
{u'id': 18446744073709551615L}
>>> ujson.loads('{"id": %d}' % 2**64)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Value is too big!
>>>
```
