### PR TITLE
Fix to avoid a crash on bounds-check fail

### DIFF
--- a/lib/ultrajsondec.c
+++ b/lib/ultrajsondec.c
@@ -448,7 +448,6 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds)
     else
     {
       wchar_t *oldStart = ds->escStart;
-      ds->escHeap = 1;
       if (newSize > (SIZE_MAX / sizeof(wchar_t)))
       {
         return SetError(ds, -1, "Could not reserve memory block");
@@ -458,6 +457,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds)
       {
         return SetError(ds, -1, "Could not reserve memory block");
       }
+      ds->escHeap = 1;
       memcpy(ds->escStart, oldStart, escLen * sizeof(wchar_t));
     }
 


### PR DESCRIPTION
Fix for #145. 

The `escHeap` flag was set too early causing a crash when `JSON_DecodeObject` later tries to free `ds.escStart` that's still on the stack.
