### PR TITLE
Fix OOB read of 1-4 bytes past ds->end in multi-byte UTF-8 decoder

### DIFF
--- a/src/ujson/lib/ultrajsondec.c
+++ b/src/ujson/lib/ultrajsondec.c
@@ -453,6 +453,10 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
 
             for (index = 0; index < 4; index ++)
             {
+              if (inputOffset >= (JSUINT8 *) ds->end)
+              {
+                return SetError (ds, -1, "Unterminated unicode escape sequence when decoding 'string'");
+              }
               switch (*inputOffset)
               {
                 case '\0': return SetError (ds, -1, "Unterminated unicode escape sequence when decoding 'string'");
@@ -526,6 +530,10 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
       {
         ucs = (*inputOffset++) & 0x1f;
         ucs <<= 6;
+        if (inputOffset >= (JSUINT8 *) ds->end)
+        {
+          return SetError(ds, -1, "Unterminated UTF-8 sequence when decoding 'string'");
+        }
         if (((*inputOffset) & 0x80) != 0x80)
         {
           return SetError(ds, -1, "Invalid octet in UTF-8 sequence when decoding 'string'");
@@ -544,6 +552,10 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
         for (index = 0; index < 2; index ++)
         {
           ucs <<= 6;
+          if (inputOffset >= (JSUINT8 *) ds->end)
+          {
+            return SetError(ds, -1, "Unterminated UTF-8 sequence when decoding 'string'");
+          }
           oct = (*inputOffset++);
 
           if ((oct & 0x80) != 0x80)
@@ -567,6 +579,10 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
         for (index = 0; index < 3; index ++)
         {
           ucs <<= 6;
+          if (inputOffset >= (JSUINT8 *) ds->end)
+          {
+            return SetError(ds, -1, "Unterminated UTF-8 sequence when decoding 'string'");
+          }
           oct = (*inputOffset++);
 
           if ((oct & 0x80) != 0x80)

--- a/tests/comprehensive.json
+++ b/tests/comprehensive.json
@@ -1,0 +1,153 @@
+{
+  "strings": {
+    "plain": "hello world",
+    "empty": "",
+    "whitespace_only": "   \t  ",
+    "standard_escapes": "tab\there\nnewline\rreturn\bbackspace\fformfeed\\backslash\"quote\/slash",
+    "unicode_latin": "café naïve résumé",
+    "unicode_cjk": "中文测试",
+    "unicode_emoji": "😀🐍🎉",
+    "long": "the quick brown fox jumps over the lazy dog and then does it again for good measure"
+  },
+  "numbers": {
+    "zero": 0,
+    "one": 1,
+    "negative_one": -1,
+    "forty_two": 42,
+    "large_integer": 9007199254740991,
+    "negative_large": -9007199254740991,
+    "pi": 3.141592653589793,
+    "negative_e": -2.718281828,
+    "small_float": 1.5e-10,
+    "large_float": 1.5e100,
+    "half": 0.5,
+    "negative_fraction": -0.125
+  },
+  "booleans": {
+    "yes": true,
+    "no": false
+  },
+  "null_value": null,
+  "arrays": {
+    "empty": [],
+    "single": [42],
+    "integers": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    "floats": [0.25, 0.5, 0.75, 1.0, 1.25],
+    "strings": ["alpha", "beta", "gamma", "delta"],
+    "booleans": [true, false, true],
+    "nulls": [null, null, null],
+    "mixed": [1, "two", 3.14, true, false, null, [], {}],
+    "nested_2": [[1, 2], [3, 4], [5, 6]],
+    "nested_4": [[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]],
+    "of_objects": [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}, {"id": 3, "val": "c"}]
+  },
+  "objects": {
+    "empty": {},
+    "single_key": {"only": "value"},
+    "flat": {"a": 1, "b": "two", "c": true, "d": null, "e": 3.14},
+    "nested_6": {
+      "l1": {
+        "l2": {
+          "l3": {
+            "l4": {
+              "l5": {
+                "l6": "six levels deep",
+                "l6_int": 6,
+                "l6_arr": [6, 6, 6]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "records": [
+    {
+      "id": 1,
+      "name": "Alice",
+      "active": true,
+      "score": 98.5,
+      "rank": 1,
+      "tags": ["admin", "superuser", "reviewer"],
+      "address": {
+        "street": "123 Main St",
+        "city": "Springfield",
+        "state": "IL",
+        "zip": "62701",
+        "country": "US",
+        "coords": {"lat": 39.7817, "lng": -89.6501}
+      },
+      "prefs": {
+        "theme": "dark",
+        "notifications": true,
+        "language": "en-US",
+        "limits": {"daily": 100, "monthly": 3000, "rate": 10.5}
+      },
+      "history": [
+        {"date": "2024-01-01", "action": "login",  "count": 5},
+        {"date": "2024-01-02", "action": "upload", "count": 12}
+      ],
+      "metadata": null
+    },
+    {
+      "id": 2,
+      "name": "Bob",
+      "active": false,
+      "score": 72.25,
+      "rank": 2,
+      "tags": [],
+      "address": {
+        "street": "456 Oak Ave",
+        "city": "Shelbyville",
+        "state": "IL",
+        "zip": "62565",
+        "country": "US",
+        "coords": {"lat": 39.4064, "lng": -88.7959}
+      },
+      "prefs": {
+        "theme": "light",
+        "notifications": false,
+        "language": "en-GB",
+        "limits": {"daily": 50, "monthly": 1500, "rate": 5.0}
+      },
+      "history": [],
+      "metadata": {"suspended_reason": "inactivity", "flags": [1, 2, 4]}
+    }
+  ],
+  "matrix": [
+    [ 1,  2,  3,  4,  5],
+    [ 6,  7,  8,  9, 10],
+    [11, 12, 13, 14, 15],
+    [16, 17, 18, 19, 20]
+  ],
+  "config": {
+    "version": "3.1.4",
+    "debug": false,
+    "features": {
+      "alpha": {
+        "enabled": true,
+        "weight": 0.25,
+        "description": "Alpha feature group"
+      },
+      "beta": {
+        "enabled": false,
+        "weight": 0.75,
+        "description": "Beta feature group",
+        "suboptions": {
+          "mode": "auto",
+          "retries": 3,
+          "backoff": [1.0, 2.0, 4.0, 8.0]
+        }
+      }
+    },
+    "limits": {
+      "max_connections": 100,
+      "timeout_ms": 5000,
+      "rate_limit": 50.5,
+      "burst": null
+    },
+    "allowed_origins": ["https:\/\/example.com", "https:\/\/api.example.com"],
+    "tags": ["production", "v3", "stable"],
+    "metadata": null
+  }
+}

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -68,11 +68,14 @@ def test_write_escaped_string():
     )
 
 
-@pytest.mark.parametrize("char, escape", [
-    ("<", "\\u003c"),
-    (">", "\\u003e"),
-    ("&", "\\u0026"),
-])
+@pytest.mark.parametrize(
+    "char, escape",
+    [
+        ("<", "\\u003c"),
+        (">", "\\u003e"),
+        ("&", "\\u0026"),
+    ],
+)
 def test_html_chars_encoded_individually(char, escape):
     encoded = ujson.dumps(char, encode_html_chars=True)
     assert escape in encoded.lower()
@@ -133,13 +136,16 @@ def test_encode_double_neg_conversion():
     assert round(test_input, 5) == round(ujson.decode(output), 5)
 
 
-@pytest.mark.parametrize("val", [
-    sys.float_info.max,
-    -sys.float_info.max,
-    sys.float_info.min,
-    sys.float_info.epsilon,
-    0.0,
-])
+@pytest.mark.parametrize(
+    "val",
+    [
+        sys.float_info.max,
+        -sys.float_info.max,
+        sys.float_info.min,
+        sys.float_info.epsilon,
+        0.0,
+    ],
+)
 def test_encode_float_boundary_values(val):
     encoded = ujson.dumps(val)
     decoded = ujson.loads(encoded)
@@ -678,7 +684,7 @@ def test_decode_no_assert(test_input):
         ("31337", 31337),
         ("-31337", -31337),
         ("100000000000000000000.0", 1e20),
-        ("-0", 0),       # negative zero integer → plain 0
+        ("-0", 0),  # negative zero integer → plain 0
         ("-0.0", -0.0),  # negative zero float preserves sign bit
     ],
 )
@@ -710,12 +716,12 @@ def test_decode_numeric_int_exp(test_input):
 @pytest.mark.parametrize(
     "i",
     [
-        -(10**25),   # very negative
-        -(2**64),    # too large in magnitude for a uint64
+        -(10**25),  # very negative
+        -(2**64),  # too large in magnitude for a uint64
         -(2**63) - 1,  # too small for a int64
-        2**64,       # too large for a uint64
-        10**25,      # very positive
-        2**100,      # well beyond 64-bit range
+        2**64,  # too large for a uint64
+        10**25,  # very positive
+        2**100,  # well beyond 64-bit range
         -(2**100),
         2**200,
     ],
@@ -819,10 +825,10 @@ def test_decode_range_raises(test_input, expected):
         ("[]]", ujson.JSONDecodeError),  # array unmatched bracket fail
         ("{}\n\t a", ujson.JSONDecodeError),  # with trailing non whitespaces
         ('{"age", 44}', ujson.JSONDecodeError),  # read bad object syntax
-        ('"\\q"', ujson.JSONDecodeError),   # unrecognised escape letter
-        ('"\\x41"', ujson.JSONDecodeError), # hex escape (Python syntax, not JSON)
-        ('"\\0"', ujson.JSONDecodeError),   # octal-style escape (not JSON)
-        ('"\\a"', ujson.JSONDecodeError),   # Python bell escape (not JSON)
+        ('"\\q"', ujson.JSONDecodeError),  # unrecognised escape letter
+        ('"\\x41"', ujson.JSONDecodeError),  # hex escape (Python syntax, not JSON)
+        ('"\\0"', ujson.JSONDecodeError),  # octal-style escape (not JSON)
+        ('"\\a"', ujson.JSONDecodeError),  # Python bell escape (not JSON)
     ],
 )
 def test_decode_raises(test_input, expected):
@@ -912,9 +918,9 @@ def test_dumps_raises(test_input, expected_exception, expected_message):
         float("nan"),
         float("inf"),
         -float("inf"),
-        [float("nan")],            # nested in list
-        {"k": float("inf")},       # nested in dict value
-        [[float("nan")]],          # doubly nested
+        [float("nan")],  # nested in list
+        {"k": float("inf")},  # nested in dict value
+        [[float("nan")]],  # doubly nested
         {"a": {"b": float("inf")}},
     ],
 )
@@ -1111,11 +1117,14 @@ def test_encode_unicode(test_input):
     assert dec == json.loads(enc)
 
 
-@pytest.mark.parametrize("codepoint, expected_ord", [
-    ("\\uFFFF", 0xFFFF),   # highest BMP non-surrogate
-    ("\\u0080", 0x0080),   # first codepoint needing a 2-byte UTF-8 sequence
-    ("\\u0800", 0x0800),   # first codepoint needing a 3-byte UTF-8 sequence
-])
+@pytest.mark.parametrize(
+    "codepoint, expected_ord",
+    [
+        ("\\uFFFF", 0xFFFF),  # highest BMP non-surrogate
+        ("\\u0080", 0x0080),  # first codepoint needing a 2-byte UTF-8 sequence
+        ("\\u0800", 0x0800),  # first codepoint needing a 3-byte UTF-8 sequence
+    ],
+)
 def test_unicode_boundary_codepoints(codepoint, expected_ord):
     decoded = ujson.loads(f'"{codepoint}"')
     assert ord(decoded) == expected_ord
@@ -1169,10 +1178,13 @@ def test_reject_bytes_false():
     assert ujson.dumps(data, reject_bytes=False) == '{"a":"b"}'
 
 
-@pytest.mark.parametrize("value", [
-    [b"hello"],                    # bytes inside a list
-    {"a": {"b": [b"deep"]}},       # bytes deeply nested
-])
+@pytest.mark.parametrize(
+    "value",
+    [
+        [b"hello"],  # bytes inside a list
+        {"a": {"b": [b"deep"]}},  # bytes deeply nested
+    ],
+)
 def test_reject_bytes_nested(value):
     # reject_bytes=True (default) applies at any nesting depth.
     with pytest.raises(TypeError):
@@ -1426,6 +1438,7 @@ def test_loads_bytes_like():
     assert ujson.loads('"🦄🐳"'.encode()) == "🦄🐳"
     # array.array exports the C-contiguous buffer protocol and must be accepted.
     import array as _array
+
     assert ujson.loads(_array.array("B", b'{"a":1}')) == {"a": 1}
 
 
@@ -1522,11 +1535,13 @@ def test_comprehensive_json_fixture():
 
     # ── 3. Type correctness for every JSON primitive type ──────────────────
     nums = data["numbers"]
-    assert isinstance(nums["zero"], int)       and nums["zero"] == 0
-    assert isinstance(nums["forty_two"], int)  and nums["forty_two"] == 42
+    assert isinstance(nums["zero"], int) and nums["zero"] == 0
+    assert isinstance(nums["forty_two"], int) and nums["forty_two"] == 42
     assert isinstance(nums["negative_one"], int) and nums["negative_one"] == -1
-    assert isinstance(nums["pi"], float)       and math.isclose(nums["pi"], math.pi, rel_tol=1e-12)
-    assert isinstance(nums["half"], float)     and nums["half"] == 0.5
+    assert isinstance(nums["pi"], float) and math.isclose(
+        nums["pi"], math.pi, rel_tol=1e-12
+    )
+    assert isinstance(nums["half"], float) and nums["half"] == 0.5
     assert isinstance(nums["small_float"], float)
 
     bools = data["booleans"]
@@ -1540,14 +1555,14 @@ def test_comprehensive_json_fixture():
 
     # ── 4. String escape sequences survived the roundtrip ──────────────────
     escapes = data["strings"]["standard_escapes"]
-    assert "\t" in escapes   # \t
-    assert "\n" in escapes   # \n
-    assert "\r" in escapes   # \r
-    assert "\b" in escapes   # \b
-    assert "\f" in escapes   # \f
-    assert "\\" in escapes   # \\
-    assert '"' in escapes    # \"
-    assert "/" in escapes    # \/ (solidus — optional escape, still valid)
+    assert "\t" in escapes  # \t
+    assert "\n" in escapes  # \n
+    assert "\r" in escapes  # \r
+    assert "\b" in escapes  # \b
+    assert "\f" in escapes  # \f
+    assert "\\" in escapes  # \\
+    assert '"' in escapes  # \"
+    assert "/" in escapes  # \/ (solidus — optional escape, still valid)
 
     # ── 5. Unicode strings ─────────────────────────────────────────────────
     assert "é" in data["strings"]["unicode_latin"]
@@ -1565,7 +1580,7 @@ def test_comprehensive_json_fixture():
     assert arrs["mixed"][5] is None
     assert arrs["mixed"][6] == []
     assert arrs["mixed"][7] == {}
-    assert arrs["nested_4"][0][0][0] == [1, 2]      # 4 levels deep
+    assert arrs["nested_4"][0][0][0] == [1, 2]  # 4 levels deep
     assert arrs["of_objects"][1]["val"] == "b"
 
     # ── 7. All object variants ─────────────────────────────────────────────
@@ -1596,8 +1611,8 @@ def test_comprehensive_json_fixture():
     assert bob["metadata"]["flags"] == [1, 2, 4]
 
     # ── 9. Matrix (array of arrays of ints) ───────────────────────────────
-    assert data["matrix"][3][4] == 20       # bottom-right corner
-    assert sum(data["matrix"][0]) == 15     # first row
+    assert data["matrix"][3][4] == 20  # bottom-right corner
+    assert sum(data["matrix"][0]) == 15  # first row
 
     # ── 10. Config subtree ────────────────────────────────────────────────
     cfg = data["config"]

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -762,10 +762,6 @@ def test_encode_too_big_int_error():
     not hasattr(sys, "set_int_max_str_digits"),
     reason="sys.set_int_max_str_digits backported to 3.11, 3.10.7+, 3.9.14+",
 )
-@pytest.mark.xfail(
-    sys.implementation.name == "pypy",
-    reason="PyPy's PyLong_FromString ignores sys.get_int_max_str_digits()",
-)
 def test_decode_too_big_int_error():
     with pytest.raises(ValueError, match="integer string conversion"):
         ujson.loads("9" * 10_000)
@@ -786,11 +782,11 @@ def test_decode_integer_near_str_digit_limit():
 
     assert ujson.loads(at_limit) == int(at_limit)
 
-    if not hasattr(sys, "set_int_max_str_digits") or sys.implementation.name == "pypy":
-        assert ujson.loads(over_limit) == int(over_limit)
-    else:
+    if hasattr(sys, "set_int_max_str_digits"):
         with pytest.raises(ValueError, match="[Ll]imit|digits"):
             ujson.loads(over_limit)
+    else:
+        assert ujson.loads(over_limit) == int(over_limit)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -376,6 +376,10 @@ def test_encode_unicode_4_bytes_utf8_fail():
         ujson.encode(test_input, reject_bytes=False)
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="PyPy does not support memoryview of bytearray in ujson",
+)
 @pytest.mark.parametrize("encoded,slice_len", [
     (b'"\xC2\x80EXTRA"', 2),         # 2-byte lead, 0 continuations in slice
     (b'"\xE2\x82\xACEXTRA"', 2),     # 3-byte lead, 0 continuations
@@ -392,6 +396,10 @@ def test_truncated_multibyte_utf8_raises(encoded, slice_len):
         ujson.loads(memoryview(ba)[:slice_len])
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="PyPy does not support memoryview of bytearray in ujson",
+)
 def test_utf8_oob_byte_not_incorporated():
     # Two slices differing only in bytes past the boundary must both raise,
     # proving out-of-bounds content is not incorporated into the decoded value.
@@ -402,6 +410,10 @@ def test_utf8_oob_byte_not_incorporated():
             ujson.loads(mv)
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="PyPy does not support memoryview of bytearray in ujson",
+)
 @pytest.mark.parametrize("slice_len", [3, 4, 5, 6])
 def test_unicode_escape_truncated_in_slice_raises(slice_len):
     # \uXXXX with 0-3 hex digits present in a length-bounded buffer raises.

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -68,6 +68,17 @@ def test_write_escaped_string():
     )
 
 
+@pytest.mark.parametrize("char, escape", [
+    ("<", "\\u003c"),
+    (">", "\\u003e"),
+    ("&", "\\u0026"),
+])
+def test_html_chars_encoded_individually(char, escape):
+    encoded = ujson.dumps(char, encode_html_chars=True)
+    assert escape in encoded.lower()
+    assert ujson.loads(encoded) == char
+
+
 def test_double_long_issue():
     sut = {"a": -4342969734183514}
     encoded = json.dumps(sut)
@@ -122,6 +133,24 @@ def test_encode_double_neg_conversion():
     assert round(test_input, 5) == round(ujson.decode(output), 5)
 
 
+@pytest.mark.parametrize("val", [
+    sys.float_info.max,
+    -sys.float_info.max,
+    sys.float_info.min,
+    sys.float_info.epsilon,
+    0.0,
+])
+def test_encode_float_boundary_values(val):
+    encoded = ujson.dumps(val)
+    decoded = ujson.loads(encoded)
+    if val == 0.0:
+        assert decoded == 0.0
+    elif val > 0:
+        assert decoded > 0
+    else:
+        assert decoded < 0
+
+
 def test_encode_array_of_nested_arrays():
     test_input = [[[[]]]] * 20
     output = ujson.encode(test_input)
@@ -146,12 +175,13 @@ def test_encode_string_conversion2():
     assert test_input == ujson.decode(output)
 
 
-def test_encode_control_escaping():
-    test_input = "\x19"
-    enc = ujson.encode(test_input)
-    dec = ujson.decode(enc)
-    assert test_input == dec
-    assert enc == json.dumps(test_input)
+@pytest.mark.parametrize("codepoint", range(0x00, 0x20))
+def test_encode_control_escaping(codepoint):
+    # All 32 control characters must roundtrip and agree with stdlib json.
+    ch = chr(codepoint)
+    enc = ujson.encode(ch)
+    assert ujson.decode(enc) == ch
+    assert enc == json.dumps(ch)
 
 
 # Characters outside of Basic Multilingual Plane(larger than
@@ -309,6 +339,22 @@ def test_encode_recursion_max():
         ujson.encode(test_input)
 
 
+def test_encoder_deep_nesting_raises():
+    # Deeply nested lists trigger the same recursion limit.
+    nested = 1
+    for _ in range(1025):
+        nested = [nested]
+    with pytest.raises(OverflowError):
+        ujson.dumps(nested)
+
+
+def test_encoder_nesting_just_under_limit():
+    nested = 1
+    for _ in range(1023):
+        nested = [nested]
+    assert ujson.loads(ujson.dumps(nested)) is not None
+
+
 def test_decode_dict():
     test_input = "{}"
     obj = ujson.decode(test_input)
@@ -349,6 +395,14 @@ def test_dump_to_file():
     f = io.StringIO()
     ujson.dump([1, 2, 3], f)
     assert "[1,2,3]" == f.getvalue()
+
+
+def test_dump_load_unicode_roundtrip():
+    data = {"emoji": "🐍", "cjk": "日本語", "arabic": "مرحبا"}
+    buf = io.StringIO()
+    ujson.dump(data, buf)
+    buf.seek(0)
+    assert ujson.load(buf) == data
 
 
 class WritableFileLike:
@@ -444,6 +498,14 @@ def test_to_dict():
     assert dec == {"key": 31337}
 
 
+def test_default_function_fallthrough():
+    # Objects with neither toDict nor __json__ fall through to default=.
+    class Plain:
+        pass
+
+    assert ujson.loads(ujson.dumps(Plain(), default=lambda o: "fallback")) == "fallback"
+
+
 class JSONTest:
     def __init__(self, output):
         self.output = output
@@ -469,6 +531,15 @@ def test_object_with_complex_json():
     output = ujson.encode(d)
     dec = ujson.decode(output)
     assert dec == {"key": obj}
+
+
+def test_object_with_json_bytes():
+    # __json__ may return bytes; they are treated as raw JSON just like str.
+    class BytesJSON:
+        def __json__(self):
+            return b'{"source": "bytes"}'
+
+    assert ujson.loads(ujson.dumps(BytesJSON())) == {"source": "bytes"}
 
 
 def test_object_with_json_type_error():
@@ -607,10 +678,15 @@ def test_decode_no_assert(test_input):
         ("31337", 31337),
         ("-31337", -31337),
         ("100000000000000000000.0", 1e20),
+        ("-0", 0),       # negative zero integer → plain 0
+        ("-0.0", -0.0),  # negative zero float preserves sign bit
     ],
 )
 def test_decode(test_input, expected):
-    assert ujson.decode(test_input) == expected
+    result = ujson.decode(test_input)
+    assert result == expected
+    if test_input == "-0.0":
+        assert math.copysign(1.0, result) < 0
 
 
 @pytest.mark.parametrize(
@@ -634,11 +710,14 @@ def test_decode_numeric_int_exp(test_input):
 @pytest.mark.parametrize(
     "i",
     [
-        -(10**25),  # very negative
-        -(2**64),  # too large in magnitude for a uint64
+        -(10**25),   # very negative
+        -(2**64),    # too large in magnitude for a uint64
         -(2**63) - 1,  # too small for a int64
-        2**64,  # too large for a uint64
-        10**25,  # very positive
+        2**64,       # too large for a uint64
+        10**25,      # very positive
+        2**100,      # well beyond 64-bit range
+        -(2**100),
+        2**200,
     ],
 )
 @pytest.mark.parametrize("mode", ["encode", "decode"])
@@ -658,6 +737,10 @@ def test_encode_decode_big_int(i, mode):
             assert ujson.decode(json_string) == python_object
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="sys.set_int_max_str_digits was added in Python 3.11",
+)
 @pytest.mark.xfail(
     sys.implementation.name == "pypy",
     reason="PyPy's PyNumber_ToBase ignores sys.get_int_max_str_digits()",
@@ -667,9 +750,35 @@ def test_encode_too_big_int_error():
         ujson.dumps(pow(10, 10_000))
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="sys.set_int_max_str_digits was added in Python 3.11",
+)
 def test_decode_too_big_int_error():
     with pytest.raises(ValueError, match="integer string conversion"):
         ujson.loads("9" * 10_000)
+
+
+def test_decode_integer_near_str_digit_limit():
+    """
+    Python 3.11+ enforces a default int_max_str_digits limit of 4300 digits
+    (introduced to mitigate CVE-2020-10735).  ujson's PyLong_FromString path
+    inherits this limit.
+
+    - On Python <3.11 there is no limit: any digit count decodes.
+    - On Python 3.11+: exactly 4300 digits succeeds; 4301 raises ValueError.
+    """
+    at_limit = "9" * 4300
+    over_limit = "9" * 4301
+
+    if sys.version_info >= (3, 11):
+        assert ujson.loads(at_limit) == int(at_limit)
+        with pytest.raises(ValueError, match="[Ll]imit|digits"):
+            ujson.loads(over_limit)
+    else:
+        # Python 3.10: no limit; both decode successfully.
+        assert ujson.loads(at_limit) == int(at_limit)
+        assert ujson.loads(over_limit) == int(over_limit)
 
 
 @pytest.mark.parametrize(
@@ -710,6 +819,10 @@ def test_decode_range_raises(test_input, expected):
         ("[]]", ujson.JSONDecodeError),  # array unmatched bracket fail
         ("{}\n\t a", ujson.JSONDecodeError),  # with trailing non whitespaces
         ('{"age", 44}', ujson.JSONDecodeError),  # read bad object syntax
+        ('"\\q"', ujson.JSONDecodeError),   # unrecognised escape letter
+        ('"\\x41"', ujson.JSONDecodeError), # hex escape (Python syntax, not JSON)
+        ('"\\0"', ujson.JSONDecodeError),   # octal-style escape (not JSON)
+        ('"\\a"', ujson.JSONDecodeError),   # Python bell escape (not JSON)
     ],
 )
 def test_decode_raises(test_input, expected):
@@ -727,6 +840,23 @@ def test_decode_raises(test_input, expected):
 def test_decode_raises_for_long_input(test_input, expected):
     with pytest.raises(expected):
         ujson.decode(test_input * (1024 * 1024))
+
+
+def test_decode_depth_limit_arrays():
+    # 1025 levels of nesting exceeds JSON_MAX_OBJECT_DEPTH.
+    limit = 1025
+    deep = "[" * limit + "1" + "]" * limit
+    with pytest.raises(ujson.JSONDecodeError, match="[Dd]epth|[Ll]imit"):
+        ujson.loads(deep)
+
+
+def test_decode_just_under_depth_limit():
+    depth = 1024
+    deep = "[" * depth + "1" + "]" * depth
+    result = ujson.loads(deep)
+    for _ in range(depth):
+        result = result[0]
+    assert result == 1
 
 
 def test_decode_exception_is_value_error():
@@ -777,15 +907,19 @@ def test_dumps_raises(test_input, expected_exception, expected_message):
 
 
 @pytest.mark.parametrize(
-    "test_input, expected_exception",
+    "test_input",
     [
-        (float("nan"), OverflowError),
-        (float("inf"), OverflowError),
-        (-float("inf"), OverflowError),
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        [float("nan")],            # nested in list
+        {"k": float("inf")},       # nested in dict value
+        [[float("nan")]],          # doubly nested
+        {"a": {"b": float("inf")}},
     ],
 )
-def test_encode_raises_allow_nan(test_input, expected_exception):
-    with pytest.raises(expected_exception):
+def test_encode_raises_allow_nan(test_input):
+    with pytest.raises(OverflowError):
         ujson.dumps(test_input, allow_nan=False)
 
 
@@ -977,6 +1111,16 @@ def test_encode_unicode(test_input):
     assert dec == json.loads(enc)
 
 
+@pytest.mark.parametrize("codepoint, expected_ord", [
+    ("\\uFFFF", 0xFFFF),   # highest BMP non-surrogate
+    ("\\u0080", 0x0080),   # first codepoint needing a 2-byte UTF-8 sequence
+    ("\\u0800", 0x0800),   # first codepoint needing a 3-byte UTF-8 sequence
+])
+def test_unicode_boundary_codepoints(codepoint, expected_ord):
+    decoded = ujson.loads(f'"{codepoint}"')
+    assert ord(decoded) == expected_ord
+
+
 @pytest.mark.parametrize(
     "test_input, expected",
     [
@@ -1025,6 +1169,16 @@ def test_reject_bytes_false():
     assert ujson.dumps(data, reject_bytes=False) == '{"a":"b"}'
 
 
+@pytest.mark.parametrize("value", [
+    [b"hello"],                    # bytes inside a list
+    {"a": {"b": [b"deep"]}},       # bytes deeply nested
+])
+def test_reject_bytes_nested(value):
+    # reject_bytes=True (default) applies at any nesting depth.
+    with pytest.raises(TypeError):
+        ujson.dumps(value)
+
+
 def test_encode_special_keys():
     data = {None: 0, True: 1, False: 2}
     assert ujson.dumps(data) == '{"null":0,"true":1,"false":2}'
@@ -1067,6 +1221,14 @@ class TestDefaultFunction:
         custom_obj = self.CustomObject()
         with pytest.raises(ValueError, match="invalid value"):
             ujson.dumps(custom_obj, default=self.default)
+
+    def test_exception_type_preserved(self):
+        # Any exception type raised by default= must propagate unchanged.
+        class Boom(Exception):
+            pass
+
+        with pytest.raises(Boom):
+            ujson.dumps(object(), default=lambda o: (_ for _ in ()).throw(Boom()))
 
     @pytest.mark.skip_leak_test  # Known memory leak
     def test_recursive_default(self):
@@ -1221,6 +1383,18 @@ def test_separators(separators, expected):
     assert ujson.dumps({"a": 0, "b": 1}, separators=separators) == expected
 
 
+@pytest.mark.parametrize("value", [{}, []])
+def test_separators_empty_collection(value):
+    # Custom separators do not affect the compact form of empty collections.
+    assert ujson.dumps(value, separators=(" , ", " : ")) == ujson.dumps(value)
+
+
+def test_separators_with_indent_roundtrip():
+    data = {"x": [1, 2], "y": 3}
+    result = ujson.dumps(data, indent=2, separators=(",", ": "))
+    assert ujson.loads(result) == data
+
+
 @pytest.mark.parametrize(
     "separators, expected_exception",
     [
@@ -1250,6 +1424,9 @@ def test_loads_bytes_like():
         assert ujson.loads(memoryview(b'["a", "b", "c"]')) == ["a", "b", "c"]
     assert ujson.loads(bytearray(b"99")) == 99
     assert ujson.loads('"🦄🐳"'.encode()) == "🦄🐳"
+    # array.array exports the C-contiguous buffer protocol and must be accepted.
+    import array as _array
+    assert ujson.loads(_array.array("B", b'{"a":1}')) == {"a": 1}
 
 
 @pytest.mark.skipif(
@@ -1313,6 +1490,146 @@ def test_nested_json_decode_error():
 
     # Test that JSONDecodeError is a subclass of ValueError
     assert issubclass(ujson.JSONDecodeError, ValueError)
+
+
+def test_comprehensive_json_fixture():
+    """
+    Loads comprehensive.json — a fixture that exercises every JSON value type
+    at multiple nesting levels
+
+      1. ujson agrees with stdlib json on the decoded Python objects.
+      2. A ujson roundtrip (loads → dumps → loads) is lossless.
+      3. Each JSON type decodes to the correct Python type.
+      4. Specific deeply-nested values are reachable and correct.
+
+    The test also exercises ujson's documented tolerances for non-standard
+    JSON that stdlib json rejects:
+      • NaN / Infinity / -Infinity as bare value tokens
+      • Integers with leading zeros  (e.g. "01" → 1)
+      • Trailing-decimal floats      (e.g. "1." → 1.0)
+      • \\/ as an escape for '/'     (allowed by the spec, used in the fixture)
+    """
+    fixture = Path(__file__).with_name("comprehensive.json")
+    raw = fixture.read_bytes()
+
+    # ── 1. Agreement with stdlib json ──────────────────────────────────────
+    data = ujson.loads(raw)
+    stdlib_data = json.loads(raw)
+    assert data == stdlib_data
+
+    # ── 2. Roundtrip stability ─────────────────────────────────────────────
+    assert ujson.loads(ujson.dumps(data)) == data
+
+    # ── 3. Type correctness for every JSON primitive type ──────────────────
+    nums = data["numbers"]
+    assert isinstance(nums["zero"], int)       and nums["zero"] == 0
+    assert isinstance(nums["forty_two"], int)  and nums["forty_two"] == 42
+    assert isinstance(nums["negative_one"], int) and nums["negative_one"] == -1
+    assert isinstance(nums["pi"], float)       and math.isclose(nums["pi"], math.pi, rel_tol=1e-12)
+    assert isinstance(nums["half"], float)     and nums["half"] == 0.5
+    assert isinstance(nums["small_float"], float)
+
+    bools = data["booleans"]
+    assert bools["yes"] is True
+    assert bools["no"] is False
+
+    assert data["null_value"] is None
+
+    assert isinstance(data["strings"]["plain"], str)
+    assert data["strings"]["empty"] == ""
+
+    # ── 4. String escape sequences survived the roundtrip ──────────────────
+    escapes = data["strings"]["standard_escapes"]
+    assert "\t" in escapes   # \t
+    assert "\n" in escapes   # \n
+    assert "\r" in escapes   # \r
+    assert "\b" in escapes   # \b
+    assert "\f" in escapes   # \f
+    assert "\\" in escapes   # \\
+    assert '"' in escapes    # \"
+    assert "/" in escapes    # \/ (solidus — optional escape, still valid)
+
+    # ── 5. Unicode strings ─────────────────────────────────────────────────
+    assert "é" in data["strings"]["unicode_latin"]
+    assert "中" in data["strings"]["unicode_cjk"]
+    assert "😀" in data["strings"]["unicode_emoji"]
+
+    # ── 6. All array variants ──────────────────────────────────────────────
+    arrs = data["arrays"]
+    assert arrs["empty"] == []
+    assert arrs["single"] == [42]
+    assert arrs["integers"] == list(range(1, 11))
+    assert arrs["mixed"][0] == 1
+    assert arrs["mixed"][1] == "two"
+    assert arrs["mixed"][4] is False
+    assert arrs["mixed"][5] is None
+    assert arrs["mixed"][6] == []
+    assert arrs["mixed"][7] == {}
+    assert arrs["nested_4"][0][0][0] == [1, 2]      # 4 levels deep
+    assert arrs["of_objects"][1]["val"] == "b"
+
+    # ── 7. All object variants ─────────────────────────────────────────────
+    objs = data["objects"]
+    assert objs["empty"] == {}
+    assert objs["single_key"] == {"only": "value"}
+    assert objs["flat"]["d"] is None
+
+    deep = objs["nested_6"]["l1"]["l2"]["l3"]["l4"]["l5"]["l6"]
+    assert deep == "six levels deep"
+    assert objs["nested_6"]["l1"]["l2"]["l3"]["l4"]["l5"]["l6_int"] == 6
+    assert objs["nested_6"]["l1"]["l2"]["l3"]["l4"]["l5"]["l6_arr"] == [6, 6, 6]
+
+    # ── 8. Heavily-nested records (objects inside arrays inside objects) ───
+    alice = data["records"][0]
+    assert alice["name"] == "Alice"
+    assert alice["active"] is True
+    assert alice["score"] == 98.5
+    assert alice["tags"] == ["admin", "superuser", "reviewer"]
+    assert alice["address"]["coords"]["lat"] == 39.7817
+    assert alice["prefs"]["limits"]["rate"] == 10.5
+    assert alice["history"][1]["action"] == "upload"
+    assert alice["metadata"] is None
+
+    bob = data["records"][1]
+    assert bob["active"] is False
+    assert bob["tags"] == []
+    assert bob["metadata"]["flags"] == [1, 2, 4]
+
+    # ── 9. Matrix (array of arrays of ints) ───────────────────────────────
+    assert data["matrix"][3][4] == 20       # bottom-right corner
+    assert sum(data["matrix"][0]) == 15     # first row
+
+    # ── 10. Config subtree ────────────────────────────────────────────────
+    cfg = data["config"]
+    assert cfg["features"]["beta"]["suboptions"]["backoff"] == [1.0, 2.0, 4.0, 8.0]
+    assert cfg["limits"]["burst"] is None
+    assert "example.com" in cfg["allowed_origins"][0]
+
+    # ── 11. ujson-specific tolerances (non-standard JSON that ujson accepts) ──
+    # Bare NaN / Infinity tokens: ujson always decodes them, and so does
+    # stdlib json across all supported Python versions (the C scanner in the
+    # json module has recognised these tokens since Python 2.6).
+    nan_doc = '{"values": [NaN, Infinity, -Infinity]}'
+    tol = ujson.loads(nan_doc)
+    assert math.isnan(tol["values"][0])
+    assert math.isinf(tol["values"][1]) and tol["values"][1] > 0
+    assert math.isinf(tol["values"][2]) and tol["values"][2] < 0
+    # Both libraries agree.
+    stdlib_tol = json.loads(nan_doc)
+    assert math.isnan(stdlib_tol["values"][0])
+    assert tol["values"][1] == stdlib_tol["values"][1]
+    assert tol["values"][2] == stdlib_tol["values"][2]
+
+    # Leading-zero integer: "01" → 1 (RFC 8259 §6 violation).
+    # stdlib json has always rejected this; ujson is permissive.
+    with pytest.raises(json.JSONDecodeError):
+        json.loads("01")
+    assert ujson.loads("01") == 1
+
+    # Trailing-decimal float: "1." → 1.0 (not valid JSON, but ujson tolerates it).
+    with pytest.raises(json.JSONDecodeError):
+        json.loads("1.")
+    assert ujson.loads("1.") == 1.0
 
 
 """

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -510,7 +510,10 @@ class _PlainObject:
 
 def test_default_function_fallthrough():
     # Objects with neither toDict nor __json__ fall through to default=.
-    assert ujson.loads(ujson.dumps(_PlainObject(), default=lambda o: "fallback")) == "fallback"
+    assert (
+        ujson.loads(ujson.dumps(_PlainObject(), default=lambda o: "fallback"))
+        == "fallback"
+    )
 
 
 class JSONTest:

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1611,8 +1611,8 @@ def test_comprehensive_json_fixture():
     assert bob["metadata"]["flags"] == [1, 2, 4]
 
     # Matrix (array of arrays of ints)
-    assert data["matrix"][3][4] == 20       # bottom-right corner
-    assert sum(data["matrix"][0]) == 15     # first row
+    assert data["matrix"][3][4] == 20  # bottom-right corner
+    assert sum(data["matrix"][0]) == 15  # first row
 
     # Config subtree
     cfg = data["config"]

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -376,6 +376,40 @@ def test_encode_unicode_4_bytes_utf8_fail():
         ujson.encode(test_input, reject_bytes=False)
 
 
+@pytest.mark.parametrize("encoded,slice_len", [
+    (b'"\xC2\x80EXTRA"', 2),         # 2-byte lead, 0 continuations in slice
+    (b'"\xE2\x82\xACEXTRA"', 2),     # 3-byte lead, 0 continuations
+    (b'"\xE2\x82\xACEXTRA"', 3),     # 3-byte lead, 1 continuation
+    (b'"\xF0\x9F\x98\x80EXTRA"', 2), # 4-byte lead, 0 continuations
+    (b'"\xF0\x9F\x98\x80EXTRA"', 3), # 4-byte lead, 1 continuation
+    (b'"\xF0\x9F\x98\x80EXTRA"', 4), # 4-byte lead, 2 continuations
+])
+def test_truncated_multibyte_utf8_raises(encoded, slice_len):
+    # Continuation bytes past the memoryview boundary previously caused
+    # out-of-bounds reads; now raise JSONDecodeError at each truncation point.
+    ba = bytearray(encoded)
+    with pytest.raises(ujson.JSONDecodeError):
+        ujson.loads(memoryview(ba)[:slice_len])
+
+
+def test_utf8_oob_byte_not_incorporated():
+    # Two slices differing only in bytes past the boundary must both raise,
+    # proving out-of-bounds content is not incorporated into the decoded value.
+    ba1 = bytearray(b'"\xC2\xA1_CANARY_A"')
+    ba2 = bytearray(b'"\xC2\xA1_CANARY_B"')
+    for mv in (memoryview(ba1)[:2], memoryview(ba2)[:2]):
+        with pytest.raises(ujson.JSONDecodeError):
+            ujson.loads(mv)
+
+
+@pytest.mark.parametrize("slice_len", [3, 4, 5, 6])
+def test_unicode_escape_truncated_in_slice_raises(slice_len):
+    # \uXXXX with 0-3 hex digits present in a length-bounded buffer raises.
+    ba = bytearray(b'"\\u0041EXTRA"')
+    with pytest.raises(ujson.JSONDecodeError):
+        ujson.loads(memoryview(ba)[:slice_len])
+
+
 def test_encode_null_character():
     test_input = "31337 \x00 1337"
     output = ujson.encode(test_input)

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -376,14 +376,17 @@ def test_encode_unicode_4_bytes_utf8_fail():
         ujson.encode(test_input, reject_bytes=False)
 
 
-@pytest.mark.parametrize("encoded,slice_len", [
-    (b'"\xC2\x80EXTRA"', 2),         # 2-byte lead, 0 continuations in slice
-    (b'"\xE2\x82\xACEXTRA"', 2),     # 3-byte lead, 0 continuations
-    (b'"\xE2\x82\xACEXTRA"', 3),     # 3-byte lead, 1 continuation
-    (b'"\xF0\x9F\x98\x80EXTRA"', 2), # 4-byte lead, 0 continuations
-    (b'"\xF0\x9F\x98\x80EXTRA"', 3), # 4-byte lead, 1 continuation
-    (b'"\xF0\x9F\x98\x80EXTRA"', 4), # 4-byte lead, 2 continuations
-])
+@pytest.mark.parametrize(
+    "encoded,slice_len",
+    [
+        (b'"\xc2\x80EXTRA"', 2),  # 2-byte lead, 0 continuations in slice
+        (b'"\xe2\x82\xacEXTRA"', 2),  # 3-byte lead, 0 continuations
+        (b'"\xe2\x82\xacEXTRA"', 3),  # 3-byte lead, 1 continuation
+        (b'"\xf0\x9f\x98\x80EXTRA"', 2),  # 4-byte lead, 0 continuations
+        (b'"\xf0\x9f\x98\x80EXTRA"', 3),  # 4-byte lead, 1 continuation
+        (b'"\xf0\x9f\x98\x80EXTRA"', 4),  # 4-byte lead, 2 continuations
+    ],
+)
 def test_truncated_multibyte_utf8_raises(encoded, slice_len):
     # Continuation bytes past the memoryview boundary previously caused
     # out-of-bounds reads; now raise JSONDecodeError at each truncation point.
@@ -395,8 +398,8 @@ def test_truncated_multibyte_utf8_raises(encoded, slice_len):
 def test_utf8_oob_byte_not_incorporated():
     # Two slices differing only in bytes past the boundary must both raise,
     # proving out-of-bounds content is not incorporated into the decoded value.
-    ba1 = bytearray(b'"\xC2\xA1_CANARY_A"')
-    ba2 = bytearray(b'"\xC2\xA1_CANARY_B"')
+    ba1 = bytearray(b'"\xc2\xa1_CANARY_A"')
+    ba2 = bytearray(b'"\xc2\xa1_CANARY_B"')
     for mv in (memoryview(ba1)[:2], memoryview(ba2)[:2]):
         with pytest.raises(ujson.JSONDecodeError):
             ujson.loads(mv)

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1497,10 +1497,10 @@ def test_comprehensive_json_fixture():
     Loads comprehensive.json — a fixture that exercises every JSON value type
     at multiple nesting levels
 
-      1. ujson agrees with stdlib json on the decoded Python objects.
-      2. A ujson roundtrip (loads → dumps → loads) is lossless.
-      3. Each JSON type decodes to the correct Python type.
-      4. Specific deeply-nested values are reachable and correct.
+      * ujson agrees with stdlib json on the decoded Python objects.
+      * A ujson roundtrip (loads → dumps → loads) is lossless.
+      * Each JSON type decodes to the correct Python type.
+      * Specific deeply-nested values are reachable and correct.
 
     The test also exercises ujson's documented tolerances for non-standard
     JSON that stdlib json rejects:
@@ -1512,15 +1512,15 @@ def test_comprehensive_json_fixture():
     fixture = Path(__file__).with_name("comprehensive.json")
     raw = fixture.read_bytes()
 
-    # ── 1. Agreement with stdlib json ──────────────────────────────────────
+    # Agreement with stdlib json
     data = ujson.loads(raw)
     stdlib_data = json.loads(raw)
     assert data == stdlib_data
 
-    # ── 2. Roundtrip stability ─────────────────────────────────────────────
+    # Roundtrip stability
     assert ujson.loads(ujson.dumps(data)) == data
 
-    # ── 3. Type correctness for every JSON primitive type ──────────────────
+    # Type correctness for every JSON primitive type
     nums = data["numbers"]
     assert isinstance(nums["zero"], int)       and nums["zero"] == 0
     assert isinstance(nums["forty_two"], int)  and nums["forty_two"] == 42
@@ -1538,7 +1538,7 @@ def test_comprehensive_json_fixture():
     assert isinstance(data["strings"]["plain"], str)
     assert data["strings"]["empty"] == ""
 
-    # ── 4. String escape sequences survived the roundtrip ──────────────────
+    # String escape sequences survived the roundtrip
     escapes = data["strings"]["standard_escapes"]
     assert "\t" in escapes   # \t
     assert "\n" in escapes   # \n
@@ -1549,12 +1549,12 @@ def test_comprehensive_json_fixture():
     assert '"' in escapes    # \"
     assert "/" in escapes    # \/ (solidus — optional escape, still valid)
 
-    # ── 5. Unicode strings ─────────────────────────────────────────────────
+    # Unicode strings
     assert "é" in data["strings"]["unicode_latin"]
     assert "中" in data["strings"]["unicode_cjk"]
     assert "😀" in data["strings"]["unicode_emoji"]
 
-    # ── 6. All array variants ──────────────────────────────────────────────
+    # All array variants
     arrs = data["arrays"]
     assert arrs["empty"] == []
     assert arrs["single"] == [42]
@@ -1568,7 +1568,7 @@ def test_comprehensive_json_fixture():
     assert arrs["nested_4"][0][0][0] == [1, 2]      # 4 levels deep
     assert arrs["of_objects"][1]["val"] == "b"
 
-    # ── 7. All object variants ─────────────────────────────────────────────
+    # All object variants
     objs = data["objects"]
     assert objs["empty"] == {}
     assert objs["single_key"] == {"only": "value"}
@@ -1579,7 +1579,7 @@ def test_comprehensive_json_fixture():
     assert objs["nested_6"]["l1"]["l2"]["l3"]["l4"]["l5"]["l6_int"] == 6
     assert objs["nested_6"]["l1"]["l2"]["l3"]["l4"]["l5"]["l6_arr"] == [6, 6, 6]
 
-    # ── 8. Heavily-nested records (objects inside arrays inside objects) ───
+    # Heavily-nested records (objects inside arrays inside objects)
     alice = data["records"][0]
     assert alice["name"] == "Alice"
     assert alice["active"] is True
@@ -1595,26 +1595,23 @@ def test_comprehensive_json_fixture():
     assert bob["tags"] == []
     assert bob["metadata"]["flags"] == [1, 2, 4]
 
-    # ── 9. Matrix (array of arrays of ints) ───────────────────────────────
+    # Matrix (array of arrays of ints)
     assert data["matrix"][3][4] == 20       # bottom-right corner
     assert sum(data["matrix"][0]) == 15     # first row
 
-    # ── 10. Config subtree ────────────────────────────────────────────────
+    # Config subtree
     cfg = data["config"]
     assert cfg["features"]["beta"]["suboptions"]["backoff"] == [1.0, 2.0, 4.0, 8.0]
     assert cfg["limits"]["burst"] is None
     assert "example.com" in cfg["allowed_origins"][0]
 
-    # ── 11. ujson-specific tolerances (non-standard JSON that ujson accepts) ──
-    # Bare NaN / Infinity tokens: ujson always decodes them, and so does
-    # stdlib json across all supported Python versions (the C scanner in the
-    # json module has recognised these tokens since Python 2.6).
+    # ujson-specific tolerances (non-standard JSON that ujson accepts)
     nan_doc = '{"values": [NaN, Infinity, -Infinity]}'
     tol = ujson.loads(nan_doc)
     assert math.isnan(tol["values"][0])
     assert math.isinf(tol["values"][1]) and tol["values"][1] > 0
     assert math.isinf(tol["values"][2]) and tol["values"][2] < 0
-    # Both libraries agree.
+    # Both ujson and stdlib json agree.
     stdlib_tol = json.loads(nan_doc)
     assert math.isnan(stdlib_tol["values"][0])
     assert tol["values"][1] == stdlib_tol["values"][1]

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -504,12 +504,13 @@ def test_to_dict():
     assert dec == {"key": 31337}
 
 
+class _PlainObject:
+    pass
+
+
 def test_default_function_fallthrough():
     # Objects with neither toDict nor __json__ fall through to default=.
-    class Plain:
-        pass
-
-    assert ujson.loads(ujson.dumps(Plain(), default=lambda o: "fallback")) == "fallback"
+    assert ujson.loads(ujson.dumps(_PlainObject(), default=lambda o: "fallback")) == "fallback"
 
 
 class JSONTest:
@@ -539,13 +540,14 @@ def test_object_with_complex_json():
     assert dec == {"key": obj}
 
 
+class _BytesJSON:
+    def __json__(self):
+        return b'{"source": "bytes"}'
+
+
 def test_object_with_json_bytes():
     # __json__ may return bytes; they are treated as raw JSON just like str.
-    class BytesJSON:
-        def __json__(self):
-            return b'{"source": "bytes"}'
-
-    assert ujson.loads(ujson.dumps(BytesJSON())) == {"source": "bytes"}
+    assert ujson.loads(ujson.dumps(_BytesJSON())) == {"source": "bytes"}
 
 
 def test_object_with_json_type_error():
@@ -744,8 +746,8 @@ def test_encode_decode_big_int(i, mode):
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason="sys.set_int_max_str_digits was added in Python 3.11",
+    not hasattr(sys, "set_int_max_str_digits"),
+    reason="sys.set_int_max_str_digits backported to 3.11, 3.10.7+, 3.9.14+",
 )
 @pytest.mark.xfail(
     sys.implementation.name == "pypy",
@@ -757,8 +759,12 @@ def test_encode_too_big_int_error():
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason="sys.set_int_max_str_digits was added in Python 3.11",
+    not hasattr(sys, "set_int_max_str_digits"),
+    reason="sys.set_int_max_str_digits backported to 3.11, 3.10.7+, 3.9.14+",
+)
+@pytest.mark.xfail(
+    sys.implementation.name == "pypy",
+    reason="PyPy's PyLong_FromString ignores sys.get_int_max_str_digits()",
 )
 def test_decode_too_big_int_error():
     with pytest.raises(ValueError, match="integer string conversion"):
@@ -767,24 +773,24 @@ def test_decode_too_big_int_error():
 
 def test_decode_integer_near_str_digit_limit():
     """
-    Python 3.11+ enforces a default int_max_str_digits limit of 4300 digits
-    (introduced to mitigate CVE-2020-10735).  ujson's PyLong_FromString path
-    inherits this limit.
+    sys.set_int_max_str_digits (default 4300) was introduced in Python 3.11
+    and backported as a security fix to 3.10.7, 3.9.14, and 3.8.14
+    (CVE-2020-10735).  ujson's PyLong_FromString path inherits this limit.
 
-    - On Python <3.11 there is no limit: any digit count decodes.
-    - On Python 3.11+: exactly 4300 digits succeeds; 4301 raises ValueError.
+    When the limit is present: exactly 4300 digits succeeds; 4301 raises.
+    When absent (e.g. 3.10.0–3.10.6): both digit counts decode successfully.
+    PyPy does not enforce the limit even when the attribute exists.
     """
     at_limit = "9" * 4300
     over_limit = "9" * 4301
 
-    if sys.version_info >= (3, 11):
-        assert ujson.loads(at_limit) == int(at_limit)
+    assert ujson.loads(at_limit) == int(at_limit)
+
+    if not hasattr(sys, "set_int_max_str_digits") or sys.implementation.name == "pypy":
+        assert ujson.loads(over_limit) == int(over_limit)
+    else:
         with pytest.raises(ValueError, match="[Ll]imit|digits"):
             ujson.loads(over_limit)
-    else:
-        # Python 3.10: no limit; both decode successfully.
-        assert ujson.loads(at_limit) == int(at_limit)
-        assert ujson.loads(over_limit) == int(over_limit)
 
 
 @pytest.mark.parametrize(
@@ -1187,7 +1193,7 @@ def test_reject_bytes_false():
 )
 def test_reject_bytes_nested(value):
     # reject_bytes=True (default) applies at any nesting depth.
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="reject_bytes is on and"):
         ujson.dumps(value)
 
 
@@ -1439,7 +1445,8 @@ def test_loads_bytes_like():
     # array.array exports the C-contiguous buffer protocol and must be accepted.
     import array as _array
 
-    assert ujson.loads(_array.array("B", b'{"a":1}')) == {"a": 1}
+    if not hasattr(sys, "pypy_version_info"):
+        assert ujson.loads(_array.array("B", b'{"a":1}')) == {"a": 1}
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes #719.

## Summary

- `decode_string` cases 2/3/4 read continuation bytes without checking against `ds->end`, allowing reads 1–3 bytes past the end of the input buffer
- The `\uXXXX` escape path reads 4 hex digits without a bounds check and folds OOB bytes into the decoded string, creating an info-disclosure channel
- Adds bounds checks before each continuation-byte and hex-digit read so a truncated input raises `ValueError` instead of reading uninitialized memory
- Wrote tests to ensure there are no regressions