### PR TITLE
Fix PyObject_IsTrue -1 return ignored on bool kwargs in dumps()

### DIFF
--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -724,24 +724,28 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     return NULL;
   }
 
-  if (oensureAscii != NULL && !PyObject_IsTrue(oensureAscii))
-  {
-    encoder.forceASCII = 0;
+  if (oensureAscii != NULL) {
+    int b = PyObject_IsTrue(oensureAscii);
+    if (b < 0) goto ERROR;
+    if (!b) encoder.forceASCII = 0;
   }
 
-  if (oencodeHTMLChars != NULL && PyObject_IsTrue(oencodeHTMLChars))
-  {
-    encoder.encodeHTMLChars = 1;
+  if (oencodeHTMLChars != NULL) {
+    int b = PyObject_IsTrue(oencodeHTMLChars);
+    if (b < 0) goto ERROR;
+    if (b) encoder.encodeHTMLChars = 1;
   }
 
-  if (oescapeForwardSlashes != NULL && !PyObject_IsTrue(oescapeForwardSlashes))
-  {
-    encoder.escapeForwardSlashes = 0;
+  if (oescapeForwardSlashes != NULL) {
+    int b = PyObject_IsTrue(oescapeForwardSlashes);
+    if (b < 0) goto ERROR;
+    if (!b) encoder.escapeForwardSlashes = 0;
   }
 
-  if (osortKeys != NULL && PyObject_IsTrue(osortKeys))
-  {
-    encoder.sortKeys = 1;
+  if (osortKeys != NULL) {
+    int b = PyObject_IsTrue(osortKeys);
+    if (b < 0) goto ERROR;
+    if (b) encoder.sortKeys = 1;
   }
 
   if (allowNan != -1)

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -361,18 +361,22 @@ def test_encoder_nesting_just_under_limit():
     assert ujson.loads(ujson.dumps(nested)) is not None
 
 
-@pytest.mark.parametrize("kwarg", [
-    "ensure_ascii",
-    "encode_html_chars",
-    "escape_forward_slashes",
-    "sort_keys",
-])
+@pytest.mark.parametrize(
+    "kwarg",
+    [
+        "ensure_ascii",
+        "encode_html_chars",
+        "escape_forward_slashes",
+        "sort_keys",
+    ],
+)
 def test_bool_kwarg_dunder_bool_exception_propagates(kwarg):
     # PyObject_IsTrue returning -1 must propagate the exception immediately
     # rather than treating -1 as a truthy value and deferring it.
     class BadBool:
         def __bool__(self):
             raise RuntimeError("__bool__ raised")
+
     with pytest.raises(RuntimeError, match="__bool__ raised"):
         ujson.dumps("hello", **{kwarg: BadBool()})
 
@@ -383,8 +387,10 @@ def test_bool_kwarg_exception_not_swallowed_by_default_path():
     class BadBool:
         def __bool__(self):
             raise RuntimeError("__bool__ raised")
+
     class NotSerializable:
         pass
+
     with pytest.raises(RuntimeError):
         ujson.dumps(NotSerializable(), ensure_ascii=BadBool(), default=lambda o: "<ok>")
 

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -361,6 +361,34 @@ def test_encoder_nesting_just_under_limit():
     assert ujson.loads(ujson.dumps(nested)) is not None
 
 
+@pytest.mark.parametrize("kwarg", [
+    "ensure_ascii",
+    "encode_html_chars",
+    "escape_forward_slashes",
+    "sort_keys",
+])
+def test_bool_kwarg_dunder_bool_exception_propagates(kwarg):
+    # PyObject_IsTrue returning -1 must propagate the exception immediately
+    # rather than treating -1 as a truthy value and deferring it.
+    class BadBool:
+        def __bool__(self):
+            raise RuntimeError("__bool__ raised")
+    with pytest.raises(RuntimeError, match="__bool__ raised"):
+        ujson.dumps("hello", **{kwarg: BadBool()})
+
+
+def test_bool_kwarg_exception_not_swallowed_by_default_path():
+    # Previously the deferred exception could be silently clobbered by
+    # downstream attribute-lookup calls, causing dumps() to return success.
+    class BadBool:
+        def __bool__(self):
+            raise RuntimeError("__bool__ raised")
+    class NotSerializable:
+        pass
+    with pytest.raises(RuntimeError):
+        ujson.dumps(NotSerializable(), ensure_ascii=BadBool(), default=lambda o: "<ok>")
+
+
 def test_decode_dict():
     test_input = "{}"
     obj = ujson.decode(test_input)


### PR DESCRIPTION
## Summary

- `PyObject_IsTrue` returns 1 (true), 0 (false), or -1 (error, exception set)
- The four boolean kwargs — `ensure_ascii`, `encode_html_chars`, `escape_forward_slashes`, `sort_keys` — treated the result as a plain C boolean, so -1 (truthy) could silently flip the flag in the wrong direction and leave a deferred exception that subsequent code might clobber
- Check the return value explicitly at all four sites and propagate any exception immediately via `goto ERROR`

Fixes #723