### PR TITLE
Fix PyObject_HasAttrString swallowing non-AttributeError exceptions

### DIFF
--- a/src/ujson/python/JSONtoObj.c
+++ b/src/ujson/python/JSONtoObj.c
@@ -300,13 +300,15 @@ PyObject* JSONFileToObj(PyObject* self, PyObject *args, PyObject *kwargs)
     return NULL;
   }
 
-  if (!PyObject_HasAttrString (file, "read"))
+  read = PyObject_GetAttrString (file, "read");
+  if (read == NULL)
   {
-    PyErr_Format (PyExc_TypeError, "expected file");
+    if (PyErr_ExceptionMatches(PyExc_AttributeError))
+    {
+      PyErr_Format (PyExc_TypeError, "expected file");
+    }
     return NULL;
   }
-
-  read = PyObject_GetAttrString (file, "read");
 
   if (!PyCallable_Check (read)) {
     Py_XDECREF(read);

--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -495,49 +495,69 @@ ISITERABLE:
     return;
   }
 
-  if (UNLIKELY(PyObject_HasAttrString(obj, "toDict")))
   {
-    PyObject* toDictResult = PyObject_CallMethod(obj, "toDict", NULL);
-    if (toDictResult == NULL)
+    PyObject *todict_fn = PyObject_GetAttrString(obj, "toDict");
+    if (todict_fn == NULL)
     {
-      goto INVALID;
+      if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+      {
+        goto INVALID;
+      }
+      PyErr_Clear();
     }
-
-    if (!PyDict_Check(toDictResult))
+    else
     {
-      PyErr_Format(PyExc_TypeError, "toDict() should return a dict, got %s",
-                   Py_TYPE(toDictResult)->tp_name);
-      Py_DECREF(toDictResult);
-      goto INVALID;
+      PyObject* toDictResult = PyObject_CallNoArgs(todict_fn);
+      Py_DECREF(todict_fn);
+      if (toDictResult == NULL)
+      {
+        goto INVALID;
+      }
+      if (!PyDict_Check(toDictResult))
+      {
+        PyErr_Format(PyExc_TypeError, "toDict() should return a dict, got %s",
+                     Py_TYPE(toDictResult)->tp_name);
+        Py_DECREF(toDictResult);
+        goto INVALID;
+      }
+      PRINTMARK();
+      tc->type = JT_OBJECT;
+      SetupDictIter(toDictResult, pc, enc);
+      return;
     }
-
-    PRINTMARK();
-    tc->type = JT_OBJECT;
-    SetupDictIter(toDictResult, pc, enc);
-    return;
   }
-  else
-  if (UNLIKELY(PyObject_HasAttrString(obj, "__json__")))
+
   {
-    PyObject* toJSONResult = PyObject_CallMethod(obj, "__json__", NULL);
-    if (toJSONResult == NULL)
+    PyObject *json_fn = PyObject_GetAttrString(obj, "__json__");
+    if (json_fn == NULL)
     {
-      goto INVALID;
+      if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+      {
+        goto INVALID;
+      }
+      PyErr_Clear();
     }
-
-    if (!PyBytes_Check(toJSONResult) && !PyUnicode_Check(toJSONResult))
+    else
     {
-      PyErr_Format(PyExc_TypeError, "__json__() should return str or bytes, got %s",
-                   Py_TYPE(toJSONResult)->tp_name);
-      Py_DECREF(toJSONResult);
-      goto INVALID;
+      PyObject* toJSONResult = PyObject_CallNoArgs(json_fn);
+      Py_DECREF(json_fn);
+      if (toJSONResult == NULL)
+      {
+        goto INVALID;
+      }
+      if (!PyBytes_Check(toJSONResult) && !PyUnicode_Check(toJSONResult))
+      {
+        PyErr_Format(PyExc_TypeError, "__json__() should return str or bytes, got %s",
+                     Py_TYPE(toJSONResult)->tp_name);
+        Py_DECREF(toJSONResult);
+        goto INVALID;
+      }
+      PRINTMARK();
+      pc->PyTypeToJSON = PyRawJSONToUTF8;
+      tc->type = JT_RAW;
+      GET_TC(tc)->rawJSONValue = toJSONResult;
+      return;
     }
-
-    PRINTMARK();
-    pc->PyTypeToJSON = PyRawJSONToUTF8;
-    tc->type = JT_RAW;
-    GET_TC(tc)->rawJSONValue = toJSONResult;
-    return;
   }
 
   if (defaultFn)
@@ -897,13 +917,15 @@ PyObject* objToJSONFile(PyObject* self, PyObject *args, PyObject *kwargs)
     return NULL;
   }
 
-  if (!PyObject_HasAttrString (file, "write"))
+  write = PyObject_GetAttrString (file, "write");
+  if (write == NULL)
   {
-    PyErr_Format (PyExc_TypeError, "expected file");
+    if (PyErr_ExceptionMatches(PyExc_AttributeError))
+    {
+      PyErr_Format (PyExc_TypeError, "expected file");
+    }
     return NULL;
   }
-
-  write = PyObject_GetAttrString (file, "write");
 
   if (!PyCallable_Check (write))
   {

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -20,11 +20,6 @@ import pytest
 import ujson
 
 
-class _FailingWriteFile:
-    def write(self, data):
-        raise OSError("simulated write failure")
-
-
 class _PoisonedAttrFile:
     def __getattr__(self, name):
         raise OSError(f"file access forbidden: {name!r}")
@@ -452,11 +447,6 @@ def test_dump_file_args_error():
         ujson.dump([], "")
     with pytest.raises(TypeError, match="expected file"):
         ujson.dump([], object())
-
-
-def test_dump_write_failure_raises():
-    with pytest.raises(OSError, match="simulated write failure"):
-        ujson.dump({"key": "value"}, _FailingWriteFile())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -441,10 +441,13 @@ def test_dump_write_failure_raises():
         ujson.dump({"key": "value"}, FailingFile())
 
 
-@pytest.mark.parametrize("fn,extra_args", [
-    pytest.param(ujson.dump, ({"k": "v"},), id="dump"),
-    pytest.param(ujson.load, (), id="load"),
-])
+@pytest.mark.parametrize(
+    "fn,extra_args",
+    [
+        pytest.param(ujson.dump, ({"k": "v"},), id="dump"),
+        pytest.param(ujson.load, (), id="load"),
+    ],
+)
 def test_file_poisoned_getattr_raises(fn, extra_args):
     # PyObject_GetAttrString (replacing the old HasAttrString) must propagate
     # non-AttributeError exceptions from __getattr__ instead of swallowing them.

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -494,7 +494,6 @@ def test_failed_dump_closed_file():
     file.close()
     with pytest.raises(ValueError, match="closed file"):
         ujson.dump([0] * 100, file)
->>>>>>> 46f75969b18e1d37da3ad0fbb1954d146e072c5d
 
 
 def test_load_file():

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -428,6 +428,32 @@ def test_dump_to_file_like_object():
 def test_dump_file_args_error():
     with pytest.raises(TypeError):
         ujson.dump([], "")
+    with pytest.raises(TypeError, match="expected file"):
+        ujson.dump([], object())
+
+
+def test_dump_write_failure_raises():
+    class FailingFile:
+        def write(self, data):
+            raise OSError("simulated write failure")
+
+    with pytest.raises(OSError, match="simulated write failure"):
+        ujson.dump({"key": "value"}, FailingFile())
+
+
+@pytest.mark.parametrize("fn,extra_args", [
+    pytest.param(ujson.dump, ({"k": "v"},), id="dump"),
+    pytest.param(ujson.load, (), id="load"),
+])
+def test_file_poisoned_getattr_raises(fn, extra_args):
+    # PyObject_GetAttrString (replacing the old HasAttrString) must propagate
+    # non-AttributeError exceptions from __getattr__ instead of swallowing them.
+    class PoisonedFile:
+        def __getattr__(self, name):
+            raise OSError(f"file access forbidden: {name!r}")
+
+    with pytest.raises(OSError, match="file access forbidden"):
+        fn(*extra_args, PoisonedFile())
 
 
 def test_load_file():
@@ -452,6 +478,8 @@ def test_load_file_like_object():
 def test_load_file_args_error():
     with pytest.raises(TypeError):
         ujson.load("[]")
+    with pytest.raises(TypeError, match="expected file"):
+        ujson.load(object())
 
 
 def test_version():
@@ -599,6 +627,30 @@ def test_object_with_to_dict_attribute_error():
     d = {"key": JSONTestAttributeError()}
     with pytest.raises(AttributeError):
         ujson.encode(d)
+
+
+def test_todict_probe_non_attribute_error_propagates():
+    # A non-AttributeError raised during the toDict attribute lookup must
+    # propagate rather than be swallowed by the old PyObject_HasAttrString.
+    class PoisonedGetattr:
+        def __getattr__(self, name):
+            raise ValueError(f"attribute lookup poisoned: {name!r}")
+
+    with pytest.raises(ValueError, match="attribute lookup poisoned"):
+        ujson.dumps(PoisonedGetattr())
+
+
+def test_json_dunder_probe_non_attribute_error_propagates():
+    # After the toDict probe clears AttributeError, the __json__ probe runs.
+    # A non-AttributeError from that lookup must also propagate.
+    class NotoDict:
+        def __getattr__(self, name):
+            if name == "toDict":
+                raise AttributeError(name)
+            raise ValueError(f"unexpected lookup: {name!r}")
+
+    with pytest.raises(ValueError, match="unexpected lookup"):
+        ujson.dumps(NotoDict())
 
 
 def test_decode_array_empty():

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -20,6 +20,28 @@ import pytest
 import ujson
 
 
+class _FailingWriteFile:
+    def write(self, data):
+        raise OSError("simulated write failure")
+
+
+class _PoisonedAttrFile:
+    def __getattr__(self, name):
+        raise OSError(f"file access forbidden: {name!r}")
+
+
+class _PoisonedGetattr:
+    def __getattr__(self, name):
+        raise ValueError(f"attribute lookup poisoned: {name!r}")
+
+
+class _NotoDict:
+    def __getattr__(self, name):
+        if name == "toDict":
+            raise AttributeError(name)
+        raise ValueError(f"unexpected lookup: {name!r}")
+
+
 def assert_almost_equal(a, b):
     assert round(abs(a - b), 7) == 0
 
@@ -433,12 +455,8 @@ def test_dump_file_args_error():
 
 
 def test_dump_write_failure_raises():
-    class FailingFile:
-        def write(self, data):
-            raise OSError("simulated write failure")
-
     with pytest.raises(OSError, match="simulated write failure"):
-        ujson.dump({"key": "value"}, FailingFile())
+        ujson.dump({"key": "value"}, _FailingWriteFile())
 
 
 @pytest.mark.parametrize("fn,extra_args", [
@@ -448,12 +466,8 @@ def test_dump_write_failure_raises():
 def test_file_poisoned_getattr_raises(fn, extra_args):
     # PyObject_GetAttrString (replacing the old HasAttrString) must propagate
     # non-AttributeError exceptions from __getattr__ instead of swallowing them.
-    class PoisonedFile:
-        def __getattr__(self, name):
-            raise OSError(f"file access forbidden: {name!r}")
-
     with pytest.raises(OSError, match="file access forbidden"):
-        fn(*extra_args, PoisonedFile())
+        fn(*extra_args, _PoisonedAttrFile())
 
 
 def test_load_file():
@@ -632,25 +646,15 @@ def test_object_with_to_dict_attribute_error():
 def test_todict_probe_non_attribute_error_propagates():
     # A non-AttributeError raised during the toDict attribute lookup must
     # propagate rather than be swallowed by the old PyObject_HasAttrString.
-    class PoisonedGetattr:
-        def __getattr__(self, name):
-            raise ValueError(f"attribute lookup poisoned: {name!r}")
-
     with pytest.raises(ValueError, match="attribute lookup poisoned"):
-        ujson.dumps(PoisonedGetattr())
+        ujson.dumps(_PoisonedGetattr())
 
 
 def test_json_dunder_probe_non_attribute_error_propagates():
     # After the toDict probe clears AttributeError, the __json__ probe runs.
     # A non-AttributeError from that lookup must also propagate.
-    class NotoDict:
-        def __getattr__(self, name):
-            if name == "toDict":
-                raise AttributeError(name)
-            raise ValueError(f"unexpected lookup: {name!r}")
-
     with pytest.raises(ValueError, match="unexpected lookup"):
-        ujson.dumps(NotoDict())
+        ujson.dumps(_NotoDict())
 
 
 def test_decode_array_empty():


### PR DESCRIPTION
## Summary

- `PyObject_HasAttrString` silently swallows all exceptions (including `MemoryError`, `KeyboardInterrupt`, custom `__getattr__` raises) at four probe sites: `toDict`, `__json__`, `write`, and `read`
- Replace each `HasAttrString` + `GetAttrString` double-lookup with a single `GetAttrString`; propagate non-`AttributeError` exceptions, clear `AttributeError` and continue as before
- Eliminates the redundant double attribute lookup at each site as a side effect

Fixes #725