### PR TITLE
Code safety - Fix portability UB in variadic NULL sentinel and PyInit defensive clear

### DIFF
--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -550,7 +550,7 @@ ISITERABLE:
       goto INVALID;
     }
 
-    newObj = PyObject_CallFunctionObjArgs(defaultFn, obj, NULL);
+    newObj = PyObject_CallFunctionObjArgs(defaultFn, obj, (PyObject *)NULL);
     if (newObj)
     {
       PRINTMARK();

--- a/src/ujson/python/ujson.c
+++ b/src/ujson/python/ujson.c
@@ -183,9 +183,15 @@ PyMODINIT_FUNC PyInit_ujson(void)
   if (mod_decimal)
   {
     PyObject* type_decimal = PyObject_GetAttrString(mod_decimal, "Decimal");
-    assert(type_decimal != NULL);
-    modulestate(module)->type_decimal = type_decimal;
     Py_DECREF(mod_decimal);
+    if (type_decimal != NULL)
+    {
+      modulestate(module)->type_decimal = type_decimal;
+    }
+    else
+    {
+      PyErr_Clear();
+    }
   }
   else
     PyErr_Clear();

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -2,6 +2,7 @@ import copy
 import datetime as dt
 import decimal
 import enum
+import importlib
 import io
 import json
 import math
@@ -29,6 +30,25 @@ def test_encode_decimal():
     encoded = ujson.encode(sut)
     decoded = ujson.decode(encoded)
     assert decoded == 1337.1337
+
+
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython",
+    reason="importlib.reload of C extensions only reliable on CPython",
+)
+def test_pyinit_defensive_clear_without_decimal_class():
+    # Covers the PyErr_Clear() branch in PyInit_ujson where
+    # PyObject_GetAttrString(mod_decimal, "Decimal") returns NULL.
+    # Temporarily remove Decimal from the module then reload ujson so the
+    # defensive else-branch executes rather than the assert that was there before.
+    orig = decimal.Decimal
+    try:
+        del decimal.Decimal
+        importlib.reload(ujson)
+        assert ujson.dumps(42) == "42"
+    finally:
+        decimal.Decimal = orig
+        importlib.reload(ujson)
 
 
 def test_encode_string_conversion():


### PR DESCRIPTION
## Summary

Two minor code safety fixes with no behavioral change on common platforms:

**1. `PyObject_CallFunctionObjArgs` NULL sentinel** (`objToJSON.c`)

Bare `NULL` as a variadic sentinel is undefined behavior on platforms where `NULL` is defined as `0` (int) and `void *` is wider. Cast to `(PyObject *)NULL` for portability. Flagged by cppcheck as `varFuncNullUB`.

**2. `PyInit_ujson` assert → defensive clear** (`ujson.c`)

A debug-only `assert(type_decimal != NULL)` left a stale exception set in release builds if `PyObject_GetAttrString("Decimal")` failed — causing `SystemError` on the next API call after module import. Replace with a conditional that stores the type if present and calls `PyErr_Clear()` otherwise, allowing the module to load without decimal support rather than leaving a hidden exception.

Both changes affect code paths that cannot be triggered from Python without patching the decimal module or running on an exotic platform. Existing `test_encode_decimal` and general encode/decode smoke tests exercise the affected code paths on the happy path.