### PR TITLE
Fix utf-8 test for graalpy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "graalpy-25"
           - "pypy3.11"
           - "3.15t"
           - "3.15"
@@ -79,7 +80,7 @@ jobs:
           plugins: pycoverage
 
       - name: Test with leak detection
-        if: "!startsWith(matrix.python-version, 'pypy') && !endsWith(matrix.python-version, 't')"
+        if: "!startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.python-version, 'graalpy') && !endsWith(matrix.python-version, 't')"
         run: python -m pytest --leak-max-loops=5000 -v
 
   cross-arch:

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -1246,8 +1246,8 @@ def test_reject_bytes_false_codepoint_boundaries(codepoint):
         (b"\xfc:", "Unsupported UTF-8 sequence length when encoding string"),
         (b"U>\xfb", "Unsupported UTF-8 sequence length when encoding string"),
         (b"\\\xf8\x98\t", "Unsupported UTF-8 sequence length when encoding string"),
-        (b"\x9b", "'utf-8' codec can't decode byte 0x9b in position 1:"),
-        (b"B\x8a", "'utf-8' codec can't decode byte 0x8a in position 2:"),
+        (b"\x9b", "'utf.8' codec can't decode byte 0x9b in position 1:"),
+        (b"B\x8a", "'utf.8' codec can't decode byte 0x8a in position 2:"),
         # Bad continuation bytes (any non-start byte not matching 0b10xx_xxxx)
         (b"\xcf\x13", "Invalid continuation byte in 2-byte UTF-8 sequence"),
         (b"\xcfa", "Invalid continuation byte in 2-byte UTF-8 sequence"),


### PR DESCRIPTION
GraalPy's str.decode() error spells utf-8 as utf_8.

Also add testing on ubuntu+graalpy to CI so this doesn't become a release time issue.

Fixes the [wheel builder pipeline](https://github.com/ultrajson/ultrajson/actions/runs/27242073932/job/80447862521#step:5:2141).
```
      def test_dump_bytes_invalid_utf8(value, error):
  >       with pytest.raises((OverflowError, UnicodeDecodeError), match=error):
  E       AssertionError: Regex pattern did not match.
  E         Expected regex: "'utf-8' codec can't decode byte 0x8a in position 2:"
  E         Actual message: "'utf_8' codec can't decode byte 0x8a in position 2: malformed input"
```
