### PR TITLE
Verify expected number of dists

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ permissions:
   contents: read
 
 env:
+  EXPECTED_DISTS: 77
   FORCE_COLOR: 1
 
 jobs:
@@ -107,6 +108,14 @@ jobs:
           python -m build --sdist
           twine check --strict dist/*
           twine check --strict dist-wheels/*
+
+      - name: "What did we get?"
+        run: |
+          ls -alR dist dist-wheels
+          echo "Number of dists, should be $EXPECTED_DISTS:"
+          files=$(find dist dist-wheels -type f | wc -l)
+          echo "$files"
+          [ "$files" -eq "$EXPECTED_DISTS" ] || exit 1
 
       - name: Publish wheels to PyPI
         if: github.event.action == 'published'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ permissions:
 
 env:
   EXPECTED_DISTS: 77
+  EXPECTED_WHEELS_SHA: 7b3b245a99cfa71a7e84c11bf5cf7ac28306d4b9
   FORCE_COLOR: 1
 
 jobs:
@@ -116,6 +117,10 @@ jobs:
           files=$(find dist dist-wheels -type f | wc -l)
           echo "$files"
           [ "$files" -eq "$EXPECTED_DISTS" ] || exit 1
+          echo "Wheel fingerprint, should be $EXPECTED_WHEELS_SHA:"
+          fingerprint=$(find dist-wheels -maxdepth 1 -type f -printf '%f\n' | sed -E 's/^ujson-[^-]+-//' | LC_ALL=C sort | sha1sum | cut -d' ' -f1)
+          echo "$fingerprint"
+          [ "$fingerprint" = "$EXPECTED_WHEELS_SHA" ] || exit 1
 
       - name: Publish wheels to PyPI
         if: github.event.action == 'published'


### PR DESCRIPTION
As suggested in https://github.com/ultrajson/ultrajson/issues/741#issuecomment-4673588047, like https://github.com/python-pillow/Pillow/pull/9239.

Sometimes changes to cibuildwheel (such as [#676](https://github.com/ultrajson/ultrajson/pull/676)) change the defaults and more or fewer wheels are built, and we don't notice until we happen to spot an unnecessary wheel, or someone reports a missing wheel for their system.

This adds a hardcoded number of dists created by the CI (`EXPECTED_DISTS`), and fails if it's different to what's actually produced.

* If it changes when expected, all good, we can change the constant.
* Otherwise unexpected changes can be investigated first.

This is inspired by the coverage.py CI: 

https://github.com/nedbat/coveragepy/blob/8827634adcfe4a4baf71cf0b3e1cd967cf9b14a2/.github/workflows/publish.yml#L76-L81
