### PR TITLE
Replace pre-commit with prek to fix deprecation warning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.x"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
 
   stubtest:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ commands =
 [testenv:lint]
 skip_install = true
 deps =
-    pre-commit-uv
+    prek
 pass_env =
-    PRE_COMMIT_COLOR
+    PREK_COLOR
 commands =
-    pre-commit run --all-files --show-diff-on-failure
+    prek run --all-files --show-diff-on-failure


### PR DESCRIPTION
The lint CI has a deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

https://github.com/ultrajson/ultrajson/actions/runs/27242073896

pre-commit/action is not planning on updating:

* https://github.com/pre-commit/action/issues/241
* https://github.com/pre-commit/action/pull/242
* https://github.com/pre-commit/action/pull/244

This will also allow to check "Require actions to be pinned to a full-length commit SHA" at https://github.com/ultrajson/ultrajson/settings/actions which requires all our actions' actions to also be pinned.

pre-commit/action has repeatedly rejected pinning it, suggesting forking instead:

- https://github.com/pre-commit/action/pull/177
- https://github.com/pre-commit/action/pull/230
- https://github.com/pre-commit/action/pull/231
- https://github.com/pre-commit/action/pull/232
- https://github.com/pre-commit/action/pull/236
