### PR TITLE
Update build dependencies to avoid warning about missing [tool.setuptools_scm] section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "setuptools>=77",
-  "setuptools-scm[toml]>=3.4",
+  "setuptools>=80",
+  "setuptools-scm[simple]>=9.2",
 ]
 
 [project]
@@ -37,8 +37,6 @@ urls.Source = "https://github.com/ultrajson/ultrajson"
 
 [tool.setuptools]
 packages = [ "ujson-stubs" ]
-
-[tool.setuptools_scm]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ urls.Source = "https://github.com/ultrajson/ultrajson"
 [tool.setuptools]
 packages = [ "ujson-stubs" ]
 
+[tool.setuptools_scm]
+
 [tool.isort]
 profile = "black"
 known_first_party = [ "ujson" ]


### PR DESCRIPTION
This fixes warnings like the following printed during the build:

```
  WARNING setuptools_scm.pyproject_reading toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
  Traceback (most recent call last):
    File "/usr/lib/python3.14/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 36, in read_pyproject
      section = defn.get("tool", {})[tool_name]
                ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  KeyError: 'setuptools_scm'
```


```
toml section missing PosixPath('pyproject.toml') does not contain any of the tool sections: ['setuptools_scm', 'vcs-versioning']
```

See https://setuptools-scm.readthedocs.io/en/latest/usage/. This section is expected to be present, but it may be empty if no non-default settings are required.

This addition does not change the contents of the binary wheels.

An alternative would be to change the contents of `build-system.requires` from `["setuptools>=77", "setuptools-scm[toml]>=3.4"]` to `["setuptools>=80", "setuptools-scm[simple]>=9.2"]`; then the `[tool.setuptools_scm]` section is not expected.