### PR TITLE
Tighten UTF-8 validation for ujson.loads()-ing strings from bytes

### DIFF
--- a/src/ujson/lib/ultrajsondec.c
+++ b/src/ujson/lib/ultrajsondec.c
@@ -336,7 +336,8 @@ enum DECODESTRINGSTATE
   DS_ISQUOTE,
   DS_ISESCAPE,
   DS_UTFLENERROR,
-
+  DS_CONT,
+  DS_EXCEEDSMAX,
 };
 
 static const JSUINT8 g_decoderLookup[256] =
@@ -349,14 +350,14 @@ static const JSUINT8 g_decoderLookup[256] =
   /* 0x50 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, DS_ISESCAPE, 1, 1, 1,
   /* 0x60 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
   /* 0x70 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  /* 0x80 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  /* 0x90 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  /* 0xa0 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  /* 0xb0 */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  /* 0x80 */ DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT,
+  /* 0x90 */ DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT,
+  /* 0xa0 */ DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT,
+  /* 0xb0 */ DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT, DS_CONT,
   /* 0xc0 */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
   /* 0xd0 */ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
   /* 0xe0 */ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-  /* 0xf0 */ 4, 4, 4, 4, 4, 4, 4, 4, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR,
+  /* 0xf0 */ 4, 4, 4, 4, 4, DS_EXCEEDSMAX, DS_EXCEEDSMAX, DS_EXCEEDSMAX, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR, DS_UTFLENERROR,
 };
 
 static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds)
@@ -431,6 +432,14 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
       case DS_UTFLENERROR:
       {
         return SetError (ds, -1, "Invalid UTF-8 sequence length when decoding 'string'");
+      }
+      case DS_CONT:
+      {
+        return SetError (ds, -1, "Found UTF-8 continuation byte without corresponding start byte when decoding 'string'");
+      }
+      case DS_EXCEEDSMAX:
+      {
+        return SetError(ds, -1, "Code point > U+10FFFF encountered whilst decoding 'string'");
       }
       case DS_ISESCAPE:
       {
@@ -526,9 +535,9 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
       {
         ucs = (*inputOffset++) & 0x1f;
         ucs <<= 6;
-        if (((*inputOffset) & 0x80) != 0x80)
+        if (((*inputOffset) & 0xc0) != 0x80)
         {
-          return SetError(ds, -1, "Invalid octet in UTF-8 sequence when decoding 'string'");
+          return SetError(ds, -1, "Invalid UTF-8 continuation byte when decoding 'string'");
         }
         ucs |= (*inputOffset++) & 0x3f;
         if (ucs < 0x80) return SetError (ds, -1, "Overlong 2-byte UTF-8 sequence detected when decoding 'string'");
@@ -546,9 +555,9 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
           ucs <<= 6;
           oct = (*inputOffset++);
 
-          if ((oct & 0x80) != 0x80)
+          if ((oct & 0xc0) != 0x80)
           {
-            return SetError(ds, -1, "Invalid octet in UTF-8 sequence when decoding 'string'");
+            return SetError(ds, -1, "Invalid UTF-8 continuation byte when decoding 'string'");
           }
 
           ucs |= oct & 0x3f;
@@ -569,15 +578,16 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
           ucs <<= 6;
           oct = (*inputOffset++);
 
-          if ((oct & 0x80) != 0x80)
+          if ((oct & 0xc0) != 0x80)
           {
-            return SetError(ds, -1, "Invalid octet in UTF-8 sequence when decoding 'string'");
+            return SetError(ds, -1, "Invalid UTF-8 continuation byte when decoding 'string'");
           }
 
           ucs |= oct & 0x3f;
         }
 
         if (ucs < 0x10000) return SetError (ds, -1, "Overlong 4-byte UTF-8 sequence detected when decoding 'string'");
+        if (ucs > 0x10FFFF) return SetError(ds, -1, "Code point > U+10FFFF encountered whilst decoding 'string'");
 
         *(escOffset++) = (JSUINT32) ucs;
         break;

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -909,6 +909,57 @@ def test_decode_exception_is_value_error():
 
 
 @pytest.mark.parametrize(
+    "x, error",
+    [
+        # Bad start bytes
+        (b"\xfd", "Invalid UTF-8 sequence length"),
+        (b"\xfc:", "Invalid UTF-8 sequence length"),
+        (b"U>\xfb", "Invalid UTF-8 sequence length"),
+        (b"\\\xf8\x98\t", "Unrecognized escape sequence"),
+        (b"\x9b", "continuation byte"),
+        (b"B\x8a", "continuation byte"),
+        # Bad continuation bytes (any non-start byte not matching 0b10xx_xxxx)
+        (b"\xcf\x13", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xcfa", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xd8\xcf\xd3", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xd2\t\x8b\x84", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xe2\x17\xce", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xe2a\x17\xce", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xe2\x17a", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xe0\x9c\xc6\xde", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xf0H\xce\x9b", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xf0\xce4\x9b", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        # Truncated UTF-8 sequences
+        (b"\xc3", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"a\xe3", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"=\xe3\x8c", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\x08\x11\xe3", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        (b"\xf0\x90\x94", "Invalid UTF-8 continuation byte when decoding 'string'"),
+        # Small codepoints using longer byte sequences than they need
+        (b"\xc0\xa2", "Overlong 2-byte UTF-8 sequence"),
+        (b"A\xc1\x9c", "Overlong 2-byte UTF-8 sequence"),
+        (b"\xc1\xbf", "Overlong 2-byte UTF-8 sequence"),
+        (b"N\xc0\xb4\xb4", "Overlong 2-byte UTF-8 sequence"),
+        (b"\xe0\x9d\xb3", "Overlong 3-byte UTF-8 sequence"),
+        (b"E\xe0\x9e\x8b", "Overlong 3-byte UTF-8 sequence"),
+        (b"\xe0\x9f\xbf", "Overlong 3-byte UTF-8 sequence"),
+        (b"\xf0\x80\x80\x80", "Overlong 4-byte UTF-8 sequence"),
+        (b"\xf0\x8f\xbf\xbf", "Overlong 4-byte UTF-8 sequence"),
+        (b"\xf0\x85\xa7\xbd", "Overlong 4-byte UTF-8 sequence"),
+        # Codepoints above unicode max
+        (b"\xf4\x90\x80\x80", r"Code point > U\+10FFFF encountered"),
+        (b"\xf7\x8f\x99\x90", r"Code point > U\+10FFFF encountered"),
+        (b"\xf7\xbf\xbf\xbf", r"Code point > U\+10FFFF encountered"),
+    ],
+)
+def test_decode_bad_utf8_string(x, error):
+    with pytest.raises(Exception, match=error) as capture:
+        ujson.loads(b'"' + x + b'"')
+    with pytest.raises(capture.type, match=error):
+        ujson.loads(b'"' + x)
+
+
+@pytest.mark.parametrize(
     "test_input, expected",
     [
         (True, "true"),


### PR DESCRIPTION
Similar to 169eaf36b1116fece5034ee79a7a0ef3f6deedcf but for `ujson.loads(b'"garbled utf-8 stuff"')`.

Fixes:

* Continuation bytes without preceding start byte being silently coerced into other characters.

* SystemError when decoding a 4-byte character > MAX_UNICODE (caused by us not checking then PyUnicode_New() complaining about what we gave it). (#716)

* Allowing continuation bytes with an invalid second bit (0b11xx_xxxx as opposed to 0b10xx_xxxx).

Fixes #716
