### PR TITLE
Test coverage sweep

### DIFF
--- a/src/ujson/lib/ultrajson.h
+++ b/src/ujson/lib/ultrajson.h
@@ -224,12 +224,6 @@ typedef struct __JSONObjectEncoder
   */
   JSPFN_ITERGETNAME iterGetName;
 
-  /*
-  Release a value as indicated by setting ti->release = 1 in the previous getValue call.
-  The ti->prv array should contain the necessary context to release the value
-  */
-  void (*releaseObject)(JSOBJ obj);
-
   /* Library functions
   Set to NULL to use STDLIB malloc,realloc,free */
   JSPFN_MALLOC malloc;

--- a/src/ujson/lib/ultrajsondec.c
+++ b/src/ujson/lib/ultrajsondec.c
@@ -378,35 +378,18 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
   {
     size_t newSize = (ds->end - ds->start);
 
-    if (ds->escHeap)
+    JSUINT32 *oldStart = ds->escStart;
+    if (newSize > (SIZE_MAX / sizeof(JSUINT32)))
     {
-      if (newSize > (SIZE_MAX / sizeof(JSUINT32)))
-      {
-        return SetError(ds, -1, "Could not reserve memory block");
-      }
-      escStart = (JSUINT32 *)ds->dec->realloc(ds->escStart, newSize * sizeof(JSUINT32));
-      if (!escStart)
-      {
-        // Don't free ds->escStart here; it gets handled in JSON_DecodeObject.
-        return SetError(ds, -1, "Could not reserve memory block");
-      }
-      ds->escStart = escStart;
+      return SetError(ds, -1, "Could not reserve memory block");
     }
-    else
+    ds->escStart = (JSUINT32 *) ds->dec->malloc(newSize * sizeof(JSUINT32));
+    if (!ds->escStart)
     {
-      JSUINT32 *oldStart = ds->escStart;
-      if (newSize > (SIZE_MAX / sizeof(JSUINT32)))
-      {
-        return SetError(ds, -1, "Could not reserve memory block");
-      }
-      ds->escStart = (JSUINT32 *) ds->dec->malloc(newSize * sizeof(JSUINT32));
-      if (!ds->escStart)
-      {
-        return SetError(ds, -1, "Could not reserve memory block");
-      }
-      ds->escHeap = 1;
-      memcpy(ds->escStart, oldStart, escLen * sizeof(JSUINT32));
+      return SetError(ds, -1, "Could not reserve memory block");
     }
+    ds->escHeap = 1;
+    memcpy(ds->escStart, oldStart, escLen * sizeof(JSUINT32));
 
     ds->escEnd = ds->escStart + newSize;
   }

--- a/src/ujson/lib/ultrajsondec.c
+++ b/src/ujson/lib/ultrajsondec.c
@@ -364,7 +364,6 @@ static FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds
 {
   int index;
   JSUINT32 *escOffset;
-  JSUINT32 *escStart;
   size_t escLen = (ds->escEnd - ds->escStart);
   JSUINT8 *inputOffset;
   JSUTF16 ch = 0;

--- a/src/ujson/lib/ultrajsonenc.c
+++ b/src/ujson/lib/ultrajsonenc.c
@@ -188,7 +188,7 @@ static FASTCALL_ATTR INLINE_PREFIX void FASTCALL_MSVC Buffer_AppendShortHexUnche
   *(outputOffset++) = g_hexChars[(value & 0x000f) >> 0];
 }
 
-static int Buffer_EscapeStringUnvalidated (JSONObjectEncoder *enc, const char *io, const char *end)
+static void Buffer_EscapeStringUnvalidated (JSONObjectEncoder *enc, const char *io, const char *end)
 {
   char *of = (char *) enc->offset;
 
@@ -218,7 +218,7 @@ static int Buffer_EscapeStringUnvalidated (JSONObjectEncoder *enc, const char *i
         else
         {
           enc->offset += (of - enc->offset);
-          return TRUE;
+          return;
         }
       }
       case '\"': (*of++) = '\\'; (*of++) = '\"'; break;
@@ -728,10 +728,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
     }
     else
     {
-      if (!Buffer_EscapeStringUnvalidated(enc, name, name + cbName))
-      {
-        return;
-      }
+      Buffer_EscapeStringUnvalidated(enc, name, name + cbName);
     }
 
     Buffer_AppendCharUnchecked(enc, '\"');
@@ -945,12 +942,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       }
       else
       {
-        if (!Buffer_EscapeStringUnvalidated(enc, value, value + szlen))
-        {
-          enc->endTypeContext(obj, &tc);
-          enc->level--;
-          return;
-        }
+        Buffer_EscapeStringUnvalidated(enc, value, value + szlen);
       }
 
       Buffer_AppendCharUnchecked (enc, '\"');

--- a/src/ujson/lib/ultrajsonenc.c
+++ b/src/ujson/lib/ultrajsonenc.c
@@ -709,7 +709,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
     return;
   }
 
-  if (enc->errorMsg)
+  if (enc->errorMsg)  // Out of memory
   {
     return;
   }
@@ -918,13 +918,13 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
     case JT_UTF8:
     {
       value = enc->getStringValue(obj, &tc, &szlen);
-      if(!value)
+      if (!value)
       {
         return;  // Out of memory
       }
 
       Buffer_Reserve(enc, RESERVE_STRING(szlen));
-      if (enc->errorMsg)
+      if (enc->errorMsg)  // Out of memory (via Buffer_Reserve())
       {
         enc->endTypeContext(obj, &tc);
         return;
@@ -952,13 +952,13 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
     case JT_RAW:
     {
       value = enc->getStringValue(obj, &tc, &szlen);
-      if(!value)
+      if (!value)  // Out of memory
       {
         return;
       }
 
       Buffer_Reserve(enc, szlen);
-      if (enc->errorMsg)
+      if (enc->errorMsg)  // Out of memory (via Buffer_Reserve())
       {
         enc->endTypeContext(obj, &tc);
         return;

--- a/src/ujson/lib/ultrajsonenc.c
+++ b/src/ujson/lib/ultrajsonenc.c
@@ -923,8 +923,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       value = enc->getStringValue(obj, &tc, &szlen);
       if(!value)
       {
-        SetError(obj, enc, "utf-8 encoding error");
-        return;
+        return;  // Out of memory
       }
 
       Buffer_Reserve(enc, RESERVE_STRING(szlen));
@@ -963,7 +962,6 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       value = enc->getStringValue(obj, &tc, &szlen);
       if(!value)
       {
-        SetError(obj, enc, "utf-8 encoding error");
         return;
       }
 

--- a/src/ujson/lib/ultrajsonenc.c
+++ b/src/ujson/lib/ultrajsonenc.c
@@ -987,23 +987,8 @@ char *JSON_EncodeObject(JSOBJ obj, JSONObjectEncoder *enc, char *_buffer, size_t
   {
     enc->recursionMax = JSON_MAX_RECURSION_DEPTH;
   }
-
-  if (_buffer == NULL)
-  {
-    _cbBuffer = 32768;
-    enc->start = (char *) enc->malloc (_cbBuffer);
-    if (!enc->start)
-    {
-      SetError(obj, enc, "Could not reserve memory block");
-      return NULL;
-    }
-    enc->heap = 1;
-  }
-  else
-  {
-    enc->start = _buffer;
-    enc->heap = 0;
-  }
+  enc->start = _buffer;
+  enc->heap = 0;
 
   enc->end = enc->start + _cbBuffer;
   enc->offset = enc->start;

--- a/src/ujson/python/JSONtoObj.c
+++ b/src/ujson/python/JSONtoObj.c
@@ -223,7 +223,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
       sarg = PyUnicode_AsEncodedString(arg, NULL, "surrogatepass");
       if (sarg == NULL)
       {
-        //Exception raised above us by codec according to docs
+        // Exception raisable above us by codec only through out of memory error
         return NULL;
       }
       sarg_length = PyBytes_Size(sarg);

--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -137,7 +137,7 @@ static char *PyUnicodeToUTF8Raw(JSOBJ _obj, size_t *_outLen, PyObject **pBytesOb
   PyObject *bytesObj = *pBytesObj = PyUnicode_AsEncodedString (obj, NULL, "surrogatepass");
   if (!bytesObj)
   {
-    return NULL;
+    return NULL;  // Out of memory
   }
 
   *_outLen = PyBytes_GET_SIZE(bytesObj);
@@ -793,14 +793,12 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     encoder.itemSeparatorChars = PyUnicodeToUTF8Raw(oseparatorsItem, &encoder.itemSeparatorLength, &separatorsItemBytes);
     if (encoder.itemSeparatorChars == NULL)
     {
-      PyErr_SetString(PyExc_ValueError, "item separator malformed");
-      goto ERROR;
+      goto ERROR;  // Out of memory
     }
     encoder.keySeparatorChars = PyUnicodeToUTF8Raw(oseparatorsKey, &encoder.keySeparatorLength, &separatorsKeyBytes);
     if (encoder.keySeparatorChars == NULL)
     {
-      PyErr_SetString(PyExc_ValueError, "key separator malformed");
-      goto ERROR;
+      goto ERROR;  // Out of memory
     }
   }
   else

--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -287,7 +287,7 @@ static int SortedDict_iterNext(JSOBJ obj, JSONTypeContext *tc)
     PyObject *keys = PyDict_Keys(GET_TC(tc)->dictObj);
     if (keys == NULL)
     {
-      return -1;
+      return -1;  // Out of memory
     }
     // Sort the list.
     if (PyList_Sort(keys) < 0)
@@ -316,7 +316,7 @@ static int SortedDict_iterNext(JSOBJ obj, JSONTypeContext *tc)
   GET_TC(tc)->itemValue = PyDict_GetItem(GET_TC(tc)->dictObj, key);
   if (!GET_TC(tc)->itemValue)
   {
-    return -1;
+    return -1;  // Reachable only by concurrently deleting keys whilst serialising
   }
   GET_TC(tc)->index++;
   return 1;
@@ -345,7 +345,7 @@ static void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObject
   int level = 0;
   TypeContext *pc;
   PRINTMARK();
-  if (!_obj)
+  if (!_obj)  // Reachable only by making iterGetValue() fail (e.g. truncating a list mid-serialisation)
   {
     tc->type = JT_INVALID;
     return;
@@ -392,7 +392,7 @@ BEGIN:
     }
     if (!PyErr_ExceptionMatches(PyExc_OverflowError))
     {
-      goto INVALID;
+      goto INVALID;  // Probably out of memory
     }
     PyErr_Clear();
     pc->PyTypeToJSON = PyLongToUINT64;
@@ -404,7 +404,7 @@ BEGIN:
     }
     if (!PyErr_ExceptionMatches(PyExc_OverflowError))
     {
-      goto INVALID;
+      goto INVALID;  // Probably out of memory
     }
     PyErr_Clear();
     GET_TC(tc)->rawJSONValue = PyNumber_ToBase(obj, 10);
@@ -860,7 +860,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 
   return newobj;
 
-ERROR:
+ERROR:  // Out of memory
   Py_XDECREF(separatorsItemBytes);
   Py_XDECREF(separatorsKeyBytes);
   return NULL;
@@ -898,7 +898,7 @@ PyObject* objToJSONFile(PyObject* self, PyObject *args, PyObject *kwargs)
   }
 
   argtuple = PyTuple_Pack(1, data);
-  if (argtuple == NULL)
+  if (argtuple == NULL)  // Out of memory
   {
     Py_XDECREF(write);
     return NULL;
@@ -916,7 +916,7 @@ PyObject* objToJSONFile(PyObject* self, PyObject *args, PyObject *kwargs)
   Py_XDECREF(argtuple);
 
   argtuple = PyTuple_Pack (1, string);
-  if (argtuple == NULL)
+  if (argtuple == NULL)  // Out of memory
   {
     Py_XDECREF(write);
     Py_DECREF(string);

--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -373,12 +373,6 @@ static void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc, JSONObject
   pc->rawJSONValue = NULL;
 
 BEGIN:
-  if (PyIter_Check(obj))
-  {
-    PRINTMARK();
-    goto ISITERABLE;
-  }
-
   if (PyBool_Check(obj))
   {
     PRINTMARK();
@@ -458,8 +452,7 @@ BEGIN:
     pc->PyTypeToJSON = PyFloatToDOUBLE; tc->type = JT_DOUBLE;
     return;
   }
-
-ISITERABLE:
+  else
   if (PyDict_Check(obj))
   {
     PRINTMARK();

--- a/src/ujson/python/objToJSON.c
+++ b/src/ujson/python/objToJSON.c
@@ -625,11 +625,6 @@ static double Object_getDoubleValue(JSOBJ obj, JSONTypeContext *tc)
   return ret;
 }
 
-static void Object_releaseObject(JSOBJ _obj)
-{
-  Py_DECREF( (PyObject *) _obj);
-}
-
 static int Object_iterNext(JSOBJ obj, JSONTypeContext *tc)
 {
   obj = GET_OBJ(obj, tc);
@@ -690,7 +685,6 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
     Object_iterEnd,
     Object_iterGetValue,
     Object_iterGetName,
-    Object_releaseObject,
     PyObject_Malloc,
     PyObject_Realloc,
     PyObject_Free,

--- a/tests/test_ujson.py
+++ b/tests/test_ujson.py
@@ -182,6 +182,25 @@ def test_encode_string_conversion2():
     assert test_input == ujson.decode(output)
 
 
+@pytest.mark.parametrize("ensure_ascii", [True, False])
+def test_encode_special_strings(ensure_ascii):
+    assert (
+        ujson.encode("/", ensure_ascii=ensure_ascii, escape_forward_slashes=False)
+        == '"/"'
+    )
+    assert (
+        ujson.encode("/", ensure_ascii=ensure_ascii, escape_forward_slashes=True)
+        == '"\\/"'
+    )
+    assert ujson.encode('"', ensure_ascii=ensure_ascii) == '"\\""'
+
+
+@pytest.mark.parametrize("ensure_ascii", [True, False])
+def test_encode_invalid_keys(ensure_ascii):
+    with pytest.raises(Exception, match="Unterminated UTF-8|can't decode byte 0xee"):
+        ujson.dumps({b"\xee": "hello"}, ensure_ascii=ensure_ascii)
+
+
 @pytest.mark.parametrize("codepoint", range(0x00, 0x20))
 def test_encode_control_escaping(codepoint):
     # All 32 control characters must roundtrip and agree with stdlib json.
@@ -377,15 +396,16 @@ def test_encode_unicode_4_bytes_utf8_fail():
         ujson.encode(test_input, reject_bytes=False)
 
 
-def test_encode_null_character():
+@pytest.mark.parametrize("ensure_ascii", [True, False])
+def test_encode_null_character(ensure_ascii):
     test_input = "31337 \x00 1337"
-    output = ujson.encode(test_input)
+    output = ujson.encode(test_input, ensure_ascii=ensure_ascii)
     assert test_input == json.loads(output)
     assert output == json.dumps(test_input)
     assert test_input == ujson.decode(output)
 
     test_input = "\x00"
-    output = ujson.encode(test_input)
+    output = ujson.encode(test_input, ensure_ascii=ensure_ascii)
     assert test_input == json.loads(output)
     assert output == json.dumps(test_input)
     assert test_input == ujson.decode(output)
@@ -700,6 +720,8 @@ def test_sort_keys_unordered():
     assert ujson.dumps(data) == '{"a":1,"1":2,"null":3}'
     with pytest.raises(TypeError):
         ujson.dumps(data, sort_keys=True)
+    with pytest.raises(TypeError):
+        ujson.dumps([[0] * 100000, data], sort_keys=True)
 
 
 @pytest.mark.parametrize(
@@ -911,6 +933,22 @@ def test_decode_exception_is_value_error():
 @pytest.mark.parametrize(
     "x, error",
     [
+        ('"a\x00b"', "Unmatched '\\\""),
+        ('"\\"', "Unmatched '\\\""),
+        (b'"\xc3\x00"', "Invalid UTF-8 continuation"),
+        ('"\\u00e\x00"', "Unterminated unicode escape sequence"),
+        ('"\\u123z"', "Unexpected character in unicode escape"),
+        ('"\\\x00"', "Unterminated escape sequence"),
+    ],
+)
+def test_decode_invalid_string(x, error):
+    with pytest.raises(Exception, match=error):
+        ujson.loads(x)
+
+
+@pytest.mark.parametrize(
+    "x, error",
+    [
         # Bad start bytes
         (b"\xfd", "Invalid UTF-8 sequence length"),
         (b"\xfc:", "Invalid UTF-8 sequence length"),
@@ -1072,6 +1110,16 @@ def test_special_singletons():
 def test_incomplete_special_inputs(test_input, expected_message):
     with pytest.raises(ujson.JSONDecodeError, match=expected_message):
         ujson.loads(test_input)
+
+
+@pytest.mark.parametrize("word", ["Infinity", "NaN", "null", "true", "false"])
+def test_incomplete_special_inputs_2(word):
+    for length in range(1, len(word)):
+        test_input = word[:length]
+        with pytest.raises(ujson.JSONDecodeError):
+            ujson.loads(test_input)
+        with pytest.raises(ujson.JSONDecodeError):
+            ujson.loads(test_input + "z")
 
 
 @pytest.mark.parametrize(
@@ -1668,6 +1716,81 @@ def test_nested_json_decode_error():
 
     # Test that JSONDecodeError is a subclass of ValueError
     assert issubclass(ujson.JSONDecodeError, ValueError)
+
+
+def test_bad_arguments():
+    with pytest.raises(TypeError):
+        ujson.loads(object(), object())
+
+    with pytest.raises(TypeError):
+        ujson.load(object())
+
+    with pytest.raises(TypeError):
+        ujson.load(object(), object())
+
+    file = types.SimpleNamespace()
+    file.read = object()
+    with pytest.raises(TypeError, match="expected file"):
+        ujson.load(file)
+
+    file.read = lambda x: None
+    with pytest.raises(TypeError, match="missing 1 required positional"):
+        ujson.load(file)
+
+    file.read = lambda: 1 / 0
+    with pytest.raises(ZeroDivisionError):
+        ujson.load(file)
+
+    file.read = lambda: 3
+    with pytest.raises(TypeError):
+        ujson.load(file)
+
+
+_bad_key_counter = 0
+
+
+class BadKey(str):
+    def __hash__(self):
+        global _bad_key_counter
+        _bad_key_counter += 1
+        if _bad_key_counter % 11 == 0:
+            raise ValueError("hash error")
+        return super().__hash__()
+
+
+@pytest.mark.xfail(
+    reason="Bug: Failed PyDict_GetItem leads to silently truncated output"
+)
+@pytest.mark.skipif(
+    sys.implementation.name in ("pypy", "graalpy"),
+    reason="PyPy & GraalPy crash if .__hash__() fails",
+)
+def test_failed_dict_get():
+    a = {}
+    for i in range(100):
+        try:
+            a[BadKey(chr(i))] = i
+        except ValueError:
+            pass
+    with pytest.raises(ValueError, match="hash error"):
+        ujson.dumps(a)
+
+
+class BadToDict:
+    def __init__(self, callback):
+        self.callback = callback
+
+    def toDict(self):
+        return self.callback()
+
+
+def test_bad_todict():
+    with pytest.raises(ZeroDivisionError):
+        ujson.dumps(BadToDict(lambda: 1 / 0))
+    with pytest.raises(TypeError, match=r"toDict\(\) should return a dict, got int"):
+        ujson.dumps(BadToDict(lambda: 3))
+    with pytest.raises(TypeError, match="object object .* not JSON serializable"):
+        ujson.dumps(BadToDict(lambda: {"a": object()}))
 
 
 def test_comprehensive_json_fixture():


### PR DESCRIPTION
A trawl through the gcov misses to see if there are any more boogies like https://github.com/ultrajson/ultrajson/security/advisories/GHSA-c38f-wx89-p2xg that we would have caught had we just ran it.

No fixes in here. The one interesting bug it kicked up I pushed out into #750. (And one boring bug I xfailed.)

Changes:

* Delete some dead stuff
* Fix some of the lies in comments/error messages regarding how to get to them
* Write a load of tests. Some of these are pretty noddy but it makes reading the gcov easier to have as little avoidable red in it as possible
* Annotate anything that isn't dead but we can't reasonably cover (out of memory handling) so we at least know what they are (minus the initialisation failure paths in ujson.c which are pretty ridiculous)

With this in place, I'm a bit less apprehensive about making cleanup/performance changes.